### PR TITLE
Feature/sicd integ tests

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,7 +17,7 @@ jobs:
         run: |
           sphinx-build doc _build
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@3.9.3
+        uses: peaceiris/actions-gh-pages@v3.9.3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,7 +17,7 @@ jobs:
         run: |
           sphinx-build doc _build
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@f09b4d7e2f12f433806a6273c6b0025df1f7859d
+        uses: peaceiris/actions-gh-pages@3.9.3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages

--- a/bin/process_image.py
+++ b/bin/process_image.py
@@ -62,6 +62,9 @@ deployed_images: dict = {
     "tile_ntf": f"s3://{image_bucket}/tile.ntf",
     "tile_jpeg": f"s3://{image_bucket}/tile.jpeg",
     "tile_png": f"s3://{image_bucket}/tile.png",
+    "sicd_capella_chip_ntf": f"s3://{image_bucket}/sicd-capella-chip.ntf",
+    "sicd_umbra_chip_ntf": f"s3://{image_bucket}/sicd-umbra-chip.ntf",
+    "sicd_interferometric_hh_ntf": f"s3://{image_bucket}/sicd-interferometric-hh.nitf"
 }
 
 # call into root directory of this package so that we can run this script from anywhere.

--- a/bin/run_test.sh
+++ b/bin/run_test.sh
@@ -62,6 +62,21 @@ case $TARGET_IMAGE in
     TARGET_IMAGE="s3://test-images-${ACCOUNT}/tile.png"
     ;;
 
+  "sicd_capella_chip_ntf")
+    TARGET_IMAGE="s3://test-images-${ACCOUNT}/sicd-capella-chip.ntf"
+    TEST_TILE_COMPRESSION=NONE
+    ;;
+
+  "sicd_umbra_chip_ntf")
+    TARGET_IMAGE="s3://test-images-${ACCOUNT}/sicd-umbra-chip.ntf"
+    TEST_TILE_COMPRESSION=NONE
+    ;;
+
+  "sicd_interferometric_hh_ntf")
+    TARGET_IMAGE="s3://test-images-${ACCOUNT}/sicd-interferometric-hh.nitf"
+    TEST_TILE_COMPRESSION=NONE
+    ;;
+
 esac
 
 # Expected values from our CDK package

--- a/src/aws/osml/utils/integ_utils.py
+++ b/src/aws/osml/utils/integ_utils.py
@@ -470,6 +470,10 @@ def get_expected_image_feature_count(image: str) -> int:
         return 99200
     elif "tile" in image:
         return 2
+    elif "sicd-capella-chip" in image or "sicd-umbra-chip" in image:
+        return 100
+    elif "sicd-interferometric" in image:
+        return 15300
     else:
         raise Exception(f"Could not determine expected features for image: {image}")
 
@@ -563,6 +567,10 @@ def get_expected_region_request_count(image: str) -> int:
         expected_count = 49
     elif "tile" in image:
         expected_count = 1
+    elif "sicd-capella-chip" in image or "sicd-umbra-chip" in image:
+        expected_count = 1
+    elif "sicd-interferometric" in image:
+        expected_count = 8
 
     # Check that we got a valid region request count
     if expected_count != 0:

--- a/src/data/centerpoint.sicd-capella-chip.ntf.geojson
+++ b/src/data/centerpoint.sicd-capella-chip.ntf.geojson
@@ -1,0 +1,99 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "bbox": [
+                109.68183257229833,
+                40.26362434768428,
+                109.68261187214613,
+                40.26429231898239
+            ],
+            "id": "a3c358058d55761d0642a64055e5d80a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            109.682612,
+                            40.263764,
+                            0
+                        ],
+                        [
+                            109.682278,
+                            40.264292,
+                            0
+                        ],
+                        [
+                            109.681833,
+                            40.264153,
+                            0
+                        ],
+                        [
+                            109.682167,
+                            40.263624,
+                            0
+                        ],
+                        [
+                            109.682612,
+                            40.263764,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            204.8
+                        ],
+                        [
+                            204.8,
+                            307.2
+                        ],
+                        [
+                            307.2,
+                            307.2
+                        ],
+                        [
+                            307.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": 109.68222222222224,
+                "center_latitude": 40.263958333333335,
+                "inferenceMetadata": {
+                    "jobId": "a007cb086b65219a72b5cd5a58e945e2",
+                    "filePath": "s3://test-images-825536440648/capella-sicd121-chip1.ntf",
+                    "receiveTime": "2023-09-07T23:31:24.937142",
+                    "inferenceTime": "2023-09-07T23:31:25.683975+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "",
+                                "sourceDt": "2002-12-16T15:16:29",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/data/centerpoint.sicd-interferometric-hh.nitf.geojson
+++ b/src/data/centerpoint.sicd-interferometric-hh.nitf.geojson
@@ -1,0 +1,14387 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59273148633326,
+                35.05492525461381,
+                -106.59269487050862,
+                35.054967275868194
+            ],
+            "id": "680d6a33036f16acbe9aa2c4906e8650",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592706,
+                            35.054925,
+                            0
+                        ],
+                        [
+                            -106.592695,
+                            35.054929,
+                            0
+                        ],
+                        [
+                            -106.59272,
+                            35.054967,
+                            0
+                        ],
+                        [
+                            -106.592731,
+                            35.054964,
+                            0
+                        ],
+                        [
+                            -106.592706,
+                            35.054925,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            1971.2
+                        ],
+                        [
+                            4236.8,
+                            1996.8
+                        ],
+                        [
+                            4339.2,
+                            1996.8
+                        ],
+                        [
+                            4339.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59271317842095,
+                "center_latitude": 35.054946265241,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.915546+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59231315674707,
+                35.053659087347,
+                -106.59224336311009,
+                35.053712167872156
+            ],
+            "id": "53ac9f0deb2a85edfc7f2f3f03683e9b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592288,
+                            35.053659,
+                            0
+                        ],
+                        [
+                            -106.592243,
+                            35.053674,
+                            0
+                        ],
+                        [
+                            -106.592269,
+                            35.053712,
+                            0
+                        ],
+                        [
+                            -106.592313,
+                            35.053697,
+                            0
+                        ],
+                        [
+                            -106.592288,
+                            35.053659,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            1164.8
+                        ],
+                        [
+                            1164.8,
+                            1267.2
+                        ],
+                        [
+                            1267.2,
+                            1267.2
+                        ],
+                        [
+                            1267.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59227825992858,
+                "center_latitude": 35.053685627609575,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.903496+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59329417517436,
+                35.05553952854408,
+                -106.59324354895278,
+                35.055563857946154
+            ],
+            "id": "03df7f25d1fbd4d73e9ad33cee761fdd",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593288,
+                            35.05554,
+                            0
+                        ],
+                        [
+                            -106.593244,
+                            35.055554,
+                            0
+                        ],
+                        [
+                            -106.59325,
+                            35.055564,
+                            0
+                        ],
+                        [
+                            -106.593294,
+                            35.055549,
+                            0
+                        ],
+                        [
+                            -106.593288,
+                            35.05554,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            1644.8
+                        ],
+                        [
+                            6003.2,
+                            1747.2
+                        ],
+                        [
+                            6028.8,
+                            1747.2
+                        ],
+                        [
+                            6028.8,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59326886206358,
+                "center_latitude": 35.05555169324512,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.825922+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59364660372857,
+                35.055279095386204,
+                -106.59357681009159,
+                35.05533217591137
+            ],
+            "id": "491563a2d06ccb349d1e65e867f0bbb3",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593621,
+                            35.055279,
+                            0
+                        ],
+                        [
+                            -106.593577,
+                            35.055294,
+                            0
+                        ],
+                        [
+                            -106.593602,
+                            35.055332,
+                            0
+                        ],
+                        [
+                            -106.593647,
+                            35.055317,
+                            0
+                        ],
+                        [
+                            -106.593621,
+                            35.055279,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            684.8
+                        ],
+                        [
+                            5676.8,
+                            787.2
+                        ],
+                        [
+                            5779.2,
+                            787.2
+                        ],
+                        [
+                            5779.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59361170691008,
+                "center_latitude": 35.055305635648786,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.511375+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59252051807418,
+                35.053589966904624,
+                -106.5924507244372,
+                35.053643047429794
+            ],
+            "id": "c99bb2eced785cc0ee3fa7b491af64a7",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592495,
+                            35.05359,
+                            0
+                        ],
+                        [
+                            -106.592451,
+                            35.053605,
+                            0
+                        ],
+                        [
+                            -106.592476,
+                            35.053643,
+                            0
+                        ],
+                        [
+                            -106.592521,
+                            35.053628,
+                            0
+                        ],
+                        [
+                            -106.592495,
+                            35.05359,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            684.8
+                        ],
+                        [
+                            1164.8,
+                            787.2
+                        ],
+                        [
+                            1267.2,
+                            787.2
+                        ],
+                        [
+                            1267.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59248562125569,
+                "center_latitude": 35.053616507167206,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.642165+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59141000780788,
+                35.053520883723955,
+                -106.5913402141709,
+                35.05357396424911
+            ],
+            "id": "90ad1d1be032b607c3e6cf614c9a1b36",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591384,
+                            35.053521,
+                            0
+                        ],
+                        [
+                            -106.59134,
+                            35.053536,
+                            0
+                        ],
+                        [
+                            -106.591366,
+                            35.053574,
+                            0
+                        ],
+                        [
+                            -106.59141,
+                            35.053559,
+                            0
+                        ],
+                        [
+                            -106.591384,
+                            35.053521,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            2700.8
+                        ],
+                        [
+                            204.8,
+                            2803.2
+                        ],
+                        [
+                            307.2,
+                            2803.2
+                        ],
+                        [
+                            307.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59137511098939,
+                "center_latitude": 35.05354742398653,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.645689+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59330036923234,
+                35.05580560801303,
+                -106.59328177277477,
+                35.0558206002168
+            ],
+            "id": "9b67ed18adcf1960a68524931cb0f593",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593293,
+                            35.055806,
+                            0
+                        ],
+                        [
+                            -106.593282,
+                            35.055809,
+                            0
+                        ],
+                        [
+                            -106.593289,
+                            35.055821,
+                            0
+                        ],
+                        [
+                            -106.5933,
+                            35.055817,
+                            0
+                        ],
+                        [
+                            -106.593293,
+                            35.055806,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            1971.2
+                        ],
+                        [
+                            6588.4,
+                            1996.8
+                        ],
+                        [
+                            6618.6,
+                            1996.8
+                        ],
+                        [
+                            6618.6,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59329107100356,
+                "center_latitude": 35.05581310411491,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.675316+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59319254134225,
+                35.055841550643066,
+                -106.59314076707234,
+                35.05586760211761
+            ],
+            "id": "88d6ee8ba8b3a012910ed1311cde5f91",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593185,
+                            35.055842,
+                            0
+                        ],
+                        [
+                            -106.593141,
+                            35.055856,
+                            0
+                        ],
+                        [
+                            -106.593148,
+                            35.055868,
+                            0
+                        ],
+                        [
+                            -106.593193,
+                            35.055853,
+                            0
+                        ],
+                        [
+                            -106.593185,
+                            35.055842,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            2220.8
+                        ],
+                        [
+                            6588.4,
+                            2323.2
+                        ],
+                        [
+                            6618.6,
+                            2323.2
+                        ],
+                        [
+                            6618.6,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5931666542073,
+                "center_latitude": 35.055854576380334,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.029246+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5926306189276,
+                35.05576071395967,
+                -106.59257999270602,
+                35.055785043361745
+            ],
+            "id": "2620b12e80d2dfed381e5b1b0aa4f6f4",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592624,
+                            35.055761,
+                            0
+                        ],
+                        [
+                            -106.59258,
+                            35.055775,
+                            0
+                        ],
+                        [
+                            -106.592586,
+                            35.055785,
+                            0
+                        ],
+                        [
+                            -106.592631,
+                            35.05577,
+                            0
+                        ],
+                        [
+                            -106.592624,
+                            35.055761,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            3180.8
+                        ],
+                        [
+                            6003.2,
+                            3283.2
+                        ],
+                        [
+                            6028.8,
+                            3283.2
+                        ],
+                        [
+                            6028.8,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59260530581682,
+                "center_latitude": 35.055772878660704,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.019506+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59262365844317,
+                35.05496119724384,
+                -106.59255386480619,
+                35.055014277769004
+            ],
+            "id": "f642e430219877c2ee09cbfe4396d992",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592598,
+                            35.054961,
+                            0
+                        ],
+                        [
+                            -106.592554,
+                            35.054976,
+                            0
+                        ],
+                        [
+                            -106.592579,
+                            35.055014,
+                            0
+                        ],
+                        [
+                            -106.592624,
+                            35.055,
+                            0
+                        ],
+                        [
+                            -106.592598,
+                            35.054961,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            2220.8
+                        ],
+                        [
+                            4236.8,
+                            2323.2
+                        ],
+                        [
+                            4339.2,
+                            2323.2
+                        ],
+                        [
+                            4339.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59258876162468,
+                "center_latitude": 35.05498773750642,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.111713+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5921527451544,
+                35.05463498974372,
+                -106.59208295151741,
+                35.054688070268874
+            ],
+            "id": "88c75f1b618aeba922a3e2b132d464e5",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592127,
+                            35.054635,
+                            0
+                        ],
+                        [
+                            -106.592083,
+                            35.05465,
+                            0
+                        ],
+                        [
+                            -106.592109,
+                            35.054688,
+                            0
+                        ],
+                        [
+                            -106.592153,
+                            35.054673,
+                            0
+                        ],
+                        [
+                            -106.592127,
+                            35.054635,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            2700.8
+                        ],
+                        [
+                            3180.8,
+                            2803.2
+                        ],
+                        [
+                            3283.2,
+                            2803.2
+                        ],
+                        [
+                            3283.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5921178483359,
+                "center_latitude": 35.0546615300063,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.562223+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59293609774737,
+                35.054593498847446,
+                -106.59286630411039,
+                35.05464657937261
+            ],
+            "id": "ba95d9856a021f5c6ba763ebfa871ae8",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592911,
+                            35.054593,
+                            0
+                        ],
+                        [
+                            -106.592866,
+                            35.054608,
+                            0
+                        ],
+                        [
+                            -106.592892,
+                            35.054647,
+                            0
+                        ],
+                        [
+                            -106.592936,
+                            35.054632,
+                            0
+                        ],
+                        [
+                            -106.592911,
+                            35.054593,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            1164.8
+                        ],
+                        [
+                            3660.8,
+                            1267.2
+                        ],
+                        [
+                            3763.2,
+                            1267.2
+                        ],
+                        [
+                            3763.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59290120092888,
+                "center_latitude": 35.05462003911003,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.981544+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59198599907374,
+                35.05354851327005,
+                -106.59191620543676,
+                35.053601593795214
+            ],
+            "id": "c15b5dcdc76c96b5327920b0dfa033d8",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59196,
+                            35.053549,
+                            0
+                        ],
+                        [
+                            -106.591916,
+                            35.053563,
+                            0
+                        ],
+                        [
+                            -106.591942,
+                            35.053602,
+                            0
+                        ],
+                        [
+                            -106.591986,
+                            35.053587,
+                            0
+                        ],
+                        [
+                            -106.59196,
+                            35.053549,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            1644.8
+                        ],
+                        [
+                            684.8,
+                            1747.2
+                        ],
+                        [
+                            787.2,
+                            1747.2
+                        ],
+                        [
+                            787.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59195110225525,
+                "center_latitude": 35.05357505353263,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.115739+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59337563668981,
+                35.05563296969413,
+                -106.59330584305282,
+                35.055686050219286
+            ],
+            "id": "c5934e5bb5906be74dd5dd9af04004f7",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59335,
+                            35.055633,
+                            0
+                        ],
+                        [
+                            -106.593306,
+                            35.055648,
+                            0
+                        ],
+                        [
+                            -106.593331,
+                            35.055686,
+                            0
+                        ],
+                        [
+                            -106.593376,
+                            35.055671,
+                            0
+                        ],
+                        [
+                            -106.59335,
+                            35.055633,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            1644.8
+                        ],
+                        [
+                            6252.8,
+                            1747.2
+                        ],
+                        [
+                            6355.2,
+                            1747.2
+                        ],
+                        [
+                            6355.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59334073987131,
+                "center_latitude": 35.05565950995671,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.509121+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5927278794013,
+                35.053520846462256,
+                -106.59265808576431,
+                35.05357392698742
+            ],
+            "id": "128271eac5bd78e98ba5c533c146f00a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592702,
+                            35.053521,
+                            0
+                        ],
+                        [
+                            -106.592658,
+                            35.053536,
+                            0
+                        ],
+                        [
+                            -106.592684,
+                            35.053574,
+                            0
+                        ],
+                        [
+                            -106.592728,
+                            35.053559,
+                            0
+                        ],
+                        [
+                            -106.592702,
+                            35.053521,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            204.8
+                        ],
+                        [
+                            1164.8,
+                            307.2
+                        ],
+                        [
+                            1267.2,
+                            307.2
+                        ],
+                        [
+                            1267.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5926929825828,
+                "center_latitude": 35.05354738672484,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.401822+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59260808305508,
+                35.05334115194294,
+                -106.5925382894181,
+                35.0533942324681
+            ],
+            "id": "b2ce233bf53f12b1e3b5837072e6a4e9",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592583,
+                            35.053341,
+                            0
+                        ],
+                        [
+                            -106.592538,
+                            35.053356,
+                            0
+                        ],
+                        [
+                            -106.592564,
+                            35.053394,
+                            0
+                        ],
+                        [
+                            -106.592608,
+                            35.053379,
+                            0
+                        ],
+                        [
+                            -106.592583,
+                            35.053341,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            204.8
+                        ],
+                        [
+                            684.8,
+                            307.2
+                        ],
+                        [
+                            787.2,
+                            307.2
+                        ],
+                        [
+                            787.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59257318623659,
+                "center_latitude": 35.05336769220552,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.345062+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59196478971751,
+                35.05377520969018,
+                -106.59192817389287,
+                35.05381723094456
+            ],
+            "id": "be7f33bab6acaaea71825131e31a01b6",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591939,
+                            35.053775,
+                            0
+                        ],
+                        [
+                            -106.591928,
+                            35.053779,
+                            0
+                        ],
+                        [
+                            -106.591954,
+                            35.053817,
+                            0
+                        ],
+                        [
+                            -106.591965,
+                            35.053814,
+                            0
+                        ],
+                        [
+                            -106.591939,
+                            35.053775,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            1971.2
+                        ],
+                        [
+                            1164.8,
+                            1996.8
+                        ],
+                        [
+                            1267.2,
+                            1996.8
+                        ],
+                        [
+                            1267.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59194648180521,
+                "center_latitude": 35.05379622031737,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.514770+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59185696182742,
+                35.053811152320215,
+                -106.59178716819044,
+                35.05386423284538
+            ],
+            "id": "ae86ac8d7d38ad15ba4c4037c179bdad",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591831,
+                            35.053811,
+                            0
+                        ],
+                        [
+                            -106.591787,
+                            35.053826,
+                            0
+                        ],
+                        [
+                            -106.591813,
+                            35.053864,
+                            0
+                        ],
+                        [
+                            -106.591857,
+                            35.053849,
+                            0
+                        ],
+                        [
+                            -106.591831,
+                            35.053811,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            2220.8
+                        ],
+                        [
+                            1164.8,
+                            2323.2
+                        ],
+                        [
+                            1267.2,
+                            2323.2
+                        ],
+                        [
+                            1267.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59182206500893,
+                "center_latitude": 35.0538376925828,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.536507+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59248914372783,
+                35.054303230251186,
+                -106.59241935009085,
+                35.05435631077634
+            ],
+            "id": "cee4530219502b18583c4f3f758ac2b9",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592464,
+                            35.054303,
+                            0
+                        ],
+                        [
+                            -106.592419,
+                            35.054318,
+                            0
+                        ],
+                        [
+                            -106.592445,
+                            35.054356,
+                            0
+                        ],
+                        [
+                            -106.592489,
+                            35.054342,
+                            0
+                        ],
+                        [
+                            -106.592464,
+                            35.054303,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            1644.8
+                        ],
+                        [
+                            2700.8,
+                            1747.2
+                        ],
+                        [
+                            2803.2,
+                            1747.2
+                        ],
+                        [
+                            2803.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59245424690934,
+                "center_latitude": 35.05432977051376,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.120205+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59315316947193,
+                35.0555865304449,
+                -106.59313572106271,
+                35.05559980057619
+            ],
+            "id": "44c67c3a032fd3ab96ae7658cba93d03",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593147,
+                            35.055587,
+                            0
+                        ],
+                        [
+                            -106.593136,
+                            35.05559,
+                            0
+                        ],
+                        [
+                            -106.593142,
+                            35.0556,
+                            0
+                        ],
+                        [
+                            -106.593153,
+                            35.055596,
+                            0
+                        ],
+                        [
+                            -106.593147,
+                            35.055587,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            1971.2
+                        ],
+                        [
+                            6003.2,
+                            1996.8
+                        ],
+                        [
+                            6028.8,
+                            1996.8
+                        ],
+                        [
+                            6028.8,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59314444526731,
+                "center_latitude": 35.055593165510544,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.016040+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59304534158183,
+                35.055622473074926,
+                -106.59299471536025,
+                35.055646802477
+            ],
+            "id": "165aec27c39bcd8f202f48dc2ca5f41b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593039,
+                            35.055622,
+                            0
+                        ],
+                        [
+                            -106.592995,
+                            35.055637,
+                            0
+                        ],
+                        [
+                            -106.593001,
+                            35.055647,
+                            0
+                        ],
+                        [
+                            -106.593045,
+                            35.055632,
+                            0
+                        ],
+                        [
+                            -106.593039,
+                            35.055622,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            2220.8
+                        ],
+                        [
+                            6003.2,
+                            2323.2
+                        ],
+                        [
+                            6028.8,
+                            2323.2
+                        ],
+                        [
+                            6028.8,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59302002847105,
+                "center_latitude": 35.05563463777597,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.306640+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59187665416692,
+                35.05494664670759,
+                -106.59181627819022,
+                35.05499658801266
+            ],
+            "id": "58cea56926c6bff91be51d59602fb08c",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591851,
+                            35.054947,
+                            0
+                        ],
+                        [
+                            -106.591816,
+                            35.054958,
+                            0
+                        ],
+                        [
+                            -106.591842,
+                            35.054997,
+                            0
+                        ],
+                        [
+                            -106.591877,
+                            35.054985,
+                            0
+                        ],
+                        [
+                            -106.591851,
+                            35.054947,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            3617.2
+                        ],
+                        [
+                            3660.8,
+                            3697.8
+                        ],
+                        [
+                            3763.2,
+                            3697.8
+                        ],
+                        [
+                            3763.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59184646617857,
+                "center_latitude": 35.05497161736013,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.141141+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59323463098735,
+                35.05567997159494,
+                -106.59319801516271,
+                35.05572199284932
+            ],
+            "id": "87ff3d4f7ab02ded80802c9b36f2646a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593209,
+                            35.05568,
+                            0
+                        ],
+                        [
+                            -106.593198,
+                            35.055684,
+                            0
+                        ],
+                        [
+                            -106.593224,
+                            35.055722,
+                            0
+                        ],
+                        [
+                            -106.593235,
+                            35.055718,
+                            0
+                        ],
+                        [
+                            -106.593209,
+                            35.05568,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            1971.2
+                        ],
+                        [
+                            6252.8,
+                            1996.8
+                        ],
+                        [
+                            6355.2,
+                            1996.8
+                        ],
+                        [
+                            6355.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59321632307504,
+                "center_latitude": 35.055700982222135,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.656742+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59312680309726,
+                35.055715914224976,
+                -106.59305700946028,
+                35.05576899475013
+            ],
+            "id": "b1eda5d5088f6b66ebbe73046eb758d0",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593101,
+                            35.055716,
+                            0
+                        ],
+                        [
+                            -106.593057,
+                            35.055731,
+                            0
+                        ],
+                        [
+                            -106.593083,
+                            35.055769,
+                            0
+                        ],
+                        [
+                            -106.593127,
+                            35.055754,
+                            0
+                        ],
+                        [
+                            -106.593101,
+                            35.055716,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            2220.8
+                        ],
+                        [
+                            6252.8,
+                            2323.2
+                        ],
+                        [
+                            6355.2,
+                            2323.2
+                        ],
+                        [
+                            6355.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59309190627877,
+                "center_latitude": 35.05574245448756,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.996783+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59379035934403,
+                35.055494728809386,
+                -106.59372056570705,
+                35.05554780933455
+            ],
+            "id": "22858236277e3f0eed9474950431952b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593765,
+                            35.055495,
+                            0
+                        ],
+                        [
+                            -106.593721,
+                            35.055509,
+                            0
+                        ],
+                        [
+                            -106.593746,
+                            35.055548,
+                            0
+                        ],
+                        [
+                            -106.59379,
+                            35.055533,
+                            0
+                        ],
+                        [
+                            -106.593765,
+                            35.055495,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            684.8
+                        ],
+                        [
+                            6252.8,
+                            787.2
+                        ],
+                        [
+                            6355.2,
+                            787.2
+                        ],
+                        [
+                            6355.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59375546252554,
+                "center_latitude": 35.05552126907197,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.245107+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59244852848137,
+                35.05545882716722,
+                -106.59237873484439,
+                35.05551190769238
+            ],
+            "id": "eb0bf616df0e4e7e7e2fefe680622fbd",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592423,
+                            35.055459,
+                            0
+                        ],
+                        [
+                            -106.592379,
+                            35.055474,
+                            0
+                        ],
+                        [
+                            -106.592404,
+                            35.055512,
+                            0
+                        ],
+                        [
+                            -106.592449,
+                            35.055497,
+                            0
+                        ],
+                        [
+                            -106.592423,
+                            35.055459,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            3180.8
+                        ],
+                        [
+                            5196.8,
+                            3283.2
+                        ],
+                        [
+                            5299.2,
+                            3283.2
+                        ],
+                        [
+                            5299.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59241363166288,
+                "center_latitude": 35.055485367429796,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.911870+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59260894007404,
+                35.054482924770504,
+                -106.59253914643706,
+                35.05453600529566
+            ],
+            "id": "d35d77c7882a082278cf26222fbc843a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592583,
+                            35.054483,
+                            0
+                        ],
+                        [
+                            -106.592539,
+                            35.054498,
+                            0
+                        ],
+                        [
+                            -106.592565,
+                            35.054536,
+                            0
+                        ],
+                        [
+                            -106.592609,
+                            35.054521,
+                            0
+                        ],
+                        [
+                            -106.592583,
+                            35.054483,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            1644.8
+                        ],
+                        [
+                            3180.8,
+                            1747.2
+                        ],
+                        [
+                            3283.2,
+                            1747.2
+                        ],
+                        [
+                            3283.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59257404325555,
+                "center_latitude": 35.05450946503308,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.176358+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59319964970905,
+                35.054988826789945,
+                -106.59312985607205,
+                35.0550419073151
+            ],
+            "id": "46181adf38a2609c667f7e4a943a7449",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593174,
+                            35.054989,
+                            0
+                        ],
+                        [
+                            -106.59313,
+                            35.055004,
+                            0
+                        ],
+                        [
+                            -106.593155,
+                            35.055042,
+                            0
+                        ],
+                        [
+                            -106.5932,
+                            35.055027,
+                            0
+                        ],
+                        [
+                            -106.593174,
+                            35.054989,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            1164.8
+                        ],
+                        [
+                            4716.8,
+                            1267.2
+                        ],
+                        [
+                            4819.2,
+                            1267.2
+                        ],
+                        [
+                            4819.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59316475289054,
+                "center_latitude": 35.055015367052526,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.014528+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59258929268145,
+                35.05604263353,
+                -106.59254693607183,
+                35.05606554578445
+            ],
+            "id": "deeecbd0061a10d0b8dcaf40c7709000",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592582,
+                            35.056043,
+                            0
+                        ],
+                        [
+                            -106.592547,
+                            35.056054,
+                            0
+                        ],
+                        [
+                            -106.592554,
+                            35.056066,
+                            0
+                        ],
+                        [
+                            -106.592589,
+                            35.056054,
+                            0
+                        ],
+                        [
+                            -106.592582,
+                            35.056043,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            3617.2
+                        ],
+                        [
+                            6588.4,
+                            3697.8
+                        ],
+                        [
+                            6618.6,
+                            3697.8
+                        ],
+                        [
+                            6618.6,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59256811437663,
+                "center_latitude": 35.05605408965722,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.683938+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5923481380254,
+                35.054350232152,
+                -106.59231152220075,
+                35.05439225340638
+            ],
+            "id": "fdf6dcfe56dfb31310ea580c75ddaff5",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592323,
+                            35.05435,
+                            0
+                        ],
+                        [
+                            -106.592312,
+                            35.054354,
+                            0
+                        ],
+                        [
+                            -106.592337,
+                            35.054392,
+                            0
+                        ],
+                        [
+                            -106.592348,
+                            35.054389,
+                            0
+                        ],
+                        [
+                            -106.592323,
+                            35.05435,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            1971.2
+                        ],
+                        [
+                            2700.8,
+                            1996.8
+                        ],
+                        [
+                            2803.2,
+                            1996.8
+                        ],
+                        [
+                            2803.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59232983011307,
+                "center_latitude": 35.05437124277918,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.500621+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5922403101353,
+                35.05438617478203,
+                -106.59217051649831,
+                35.05443925530719
+            ],
+            "id": "f3ab7a75424705099d7911edde120091",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592215,
+                            35.054386,
+                            0
+                        ],
+                        [
+                            -106.592171,
+                            35.054401,
+                            0
+                        ],
+                        [
+                            -106.592196,
+                            35.054439,
+                            0
+                        ],
+                        [
+                            -106.59224,
+                            35.054425,
+                            0
+                        ],
+                        [
+                            -106.592215,
+                            35.054386,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            2220.8
+                        ],
+                        [
+                            2700.8,
+                            2323.2
+                        ],
+                        [
+                            2803.2,
+                            2323.2
+                        ],
+                        [
+                            2803.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5922054133168,
+                "center_latitude": 35.054412715044606,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.799259+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59176939684652,
+                35.0540599672819,
+                -106.59169960320953,
+                35.054113047807064
+            ],
+            "id": "47780878fb8a72efc0c1b75303bd1645",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591744,
+                            35.05406,
+                            0
+                        ],
+                        [
+                            -106.5917,
+                            35.054075,
+                            0
+                        ],
+                        [
+                            -106.591725,
+                            35.054113,
+                            0
+                        ],
+                        [
+                            -106.591769,
+                            35.054098,
+                            0
+                        ],
+                        [
+                            -106.591744,
+                            35.05406,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            2700.8
+                        ],
+                        [
+                            1644.8,
+                            2803.2
+                        ],
+                        [
+                            1747.2,
+                            2803.2
+                        ],
+                        [
+                            1747.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59173450002802,
+                "center_latitude": 35.05408650754448,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.822034+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59406345891611,
+                35.055551244785114,
+                -106.59401168464622,
+                35.05557729625965
+            ],
+            "id": "30c7a14d6a344ce2ba3c710516258bfe",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.594056,
+                            35.055551,
+                            0
+                        ],
+                        [
+                            -106.594012,
+                            35.055566,
+                            0
+                        ],
+                        [
+                            -106.594019,
+                            35.055577,
+                            0
+                        ],
+                        [
+                            -106.594063,
+                            35.055563,
+                            0
+                        ],
+                        [
+                            -106.594056,
+                            35.055551,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            204.8
+                        ],
+                        [
+                            6588.4,
+                            307.2
+                        ],
+                        [
+                            6618.6,
+                            307.2
+                        ],
+                        [
+                            6618.6,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59403757178117,
+                "center_latitude": 35.055564270522375,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.385236+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59385396505567,
+                35.055209974943836,
+                -106.5937841714187,
+                35.055263055469
+            ],
+            "id": "6ea0da66cb17921d9fb4c668ca00e3fc",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593828,
+                            35.05521,
+                            0
+                        ],
+                        [
+                            -106.593784,
+                            35.055225,
+                            0
+                        ],
+                        [
+                            -106.59381,
+                            35.055263,
+                            0
+                        ],
+                        [
+                            -106.593854,
+                            35.055248,
+                            0
+                        ],
+                        [
+                            -106.593828,
+                            35.05521,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            204.8
+                        ],
+                        [
+                            5676.8,
+                            307.2
+                        ],
+                        [
+                            5779.2,
+                            307.2
+                        ],
+                        [
+                            5779.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5938190682372,
+                "center_latitude": 35.05523651520642,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.866343+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59323102405537,
+                35.05427556344339,
+                -106.5931612304184,
+                35.054328643968546
+            ],
+            "id": "e83bcee59d08d1e6dca974ea3f2817cf",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593205,
+                            35.054276,
+                            0
+                        ],
+                        [
+                            -106.593161,
+                            35.05429,
+                            0
+                        ],
+                        [
+                            -106.593187,
+                            35.054329,
+                            0
+                        ],
+                        [
+                            -106.593231,
+                            35.054314,
+                            0
+                        ],
+                        [
+                            -106.593205,
+                            35.054276,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            204.8
+                        ],
+                        [
+                            3180.8,
+                            307.2
+                        ],
+                        [
+                            3283.2,
+                            307.2
+                        ],
+                        [
+                            3283.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5931961272369,
+                "center_latitude": 35.054302103705965,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.487725+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59285128267948,
+                35.055104949133124,
+                -106.59281466685484,
+                35.055146970387504
+            ],
+            "id": "30bffa9ee4a62fb7f74ac740c328593f",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592826,
+                            35.055105,
+                            0
+                        ],
+                        [
+                            -106.592815,
+                            35.055109,
+                            0
+                        ],
+                        [
+                            -106.59284,
+                            35.055147,
+                            0
+                        ],
+                        [
+                            -106.592851,
+                            35.055143,
+                            0
+                        ],
+                        [
+                            -106.592826,
+                            35.055105,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            1971.2
+                        ],
+                        [
+                            4716.8,
+                            1996.8
+                        ],
+                        [
+                            4819.2,
+                            1996.8
+                        ],
+                        [
+                            4819.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59283297476716,
+                "center_latitude": 35.05512595976032,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.938786+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59274345478939,
+                35.05514089176316,
+                -106.5926736611524,
+                35.05519397228832
+            ],
+            "id": "44bd27f8db2affdfb7d86e0dafd707b9",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592718,
+                            35.055141,
+                            0
+                        ],
+                        [
+                            -106.592674,
+                            35.055156,
+                            0
+                        ],
+                        [
+                            -106.592699,
+                            35.055194,
+                            0
+                        ],
+                        [
+                            -106.592743,
+                            35.055179,
+                            0
+                        ],
+                        [
+                            -106.592718,
+                            35.055141,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            2220.8
+                        ],
+                        [
+                            4716.8,
+                            2323.2
+                        ],
+                        [
+                            4819.2,
+                            2323.2
+                        ],
+                        [
+                            4819.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5927085579709,
+                "center_latitude": 35.05516743202574,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.166667+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59399772067113,
+                35.05542560836702,
+                -106.59392792703416,
+                35.05547868889217
+            ],
+            "id": "184d38739503fca2ee680bc815be33fa",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593972,
+                            35.055426,
+                            0
+                        ],
+                        [
+                            -106.593928,
+                            35.05544,
+                            0
+                        ],
+                        [
+                            -106.593953,
+                            35.055479,
+                            0
+                        ],
+                        [
+                            -106.593998,
+                            35.055464,
+                            0
+                        ],
+                        [
+                            -106.593972,
+                            35.055426,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            204.8
+                        ],
+                        [
+                            6252.8,
+                            307.2
+                        ],
+                        [
+                            6355.2,
+                            307.2
+                        ],
+                        [
+                            6355.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59396282385266,
+                "center_latitude": 35.0554521486296,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.335191+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59358299801691,
+                35.055563849251755,
+                -106.59351320437993,
+                35.05561692977692
+            ],
+            "id": "e1d49dc6506bc3db1b136aa68f2ecae3",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593557,
+                            35.055564,
+                            0
+                        ],
+                        [
+                            -106.593513,
+                            35.055579,
+                            0
+                        ],
+                        [
+                            -106.593539,
+                            35.055617,
+                            0
+                        ],
+                        [
+                            -106.593583,
+                            35.055602,
+                            0
+                        ],
+                        [
+                            -106.593557,
+                            35.055564,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            1164.8
+                        ],
+                        [
+                            6252.8,
+                            1267.2
+                        ],
+                        [
+                            6355.2,
+                            1267.2
+                        ],
+                        [
+                            6355.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59354810119842,
+                "center_latitude": 35.055590389514336,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.761732+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59270260852041,
+                35.05389185369708,
+                -106.59265198229885,
+                35.05391618309915
+            ],
+            "id": "4294786aca688a1d8875a7fcd612caea",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592696,
+                            35.053892,
+                            0
+                        ],
+                        [
+                            -106.592652,
+                            35.053907,
+                            0
+                        ],
+                        [
+                            -106.592658,
+                            35.053916,
+                            0
+                        ],
+                        [
+                            -106.592703,
+                            35.053901,
+                            0
+                        ],
+                        [
+                            -106.592696,
+                            35.053892,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            684.8
+                        ],
+                        [
+                            1971.2,
+                            787.2
+                        ],
+                        [
+                            1996.8,
+                            787.2
+                        ],
+                        [
+                            1996.8,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59267729540964,
+                "center_latitude": 35.053904018398114,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.723755+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59254219692774,
+                35.0548677560938,
+                -106.59249157070616,
+                35.054892085495865
+            ],
+            "id": "8b121b751cb1890158c57cb8b84cf815",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592536,
+                            35.054868,
+                            0
+                        ],
+                        [
+                            -106.592492,
+                            35.054883,
+                            0
+                        ],
+                        [
+                            -106.592498,
+                            35.054892,
+                            0
+                        ],
+                        [
+                            -106.592542,
+                            35.054877,
+                            0
+                        ],
+                        [
+                            -106.592536,
+                            35.054868,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            2220.8
+                        ],
+                        [
+                            3987.2,
+                            2323.2
+                        ],
+                        [
+                            4012.8,
+                            2323.2
+                        ],
+                        [
+                            4012.8,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59251688381696,
+                "center_latitude": 35.05487992079483,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.907242+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59265002481784,
+                35.054831813463764,
+                -106.5926325764086,
+                35.054845083595055
+            ],
+            "id": "f3fadf2e145b07f50959806f72d87461",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592644,
+                            35.054832,
+                            0
+                        ],
+                        [
+                            -106.592633,
+                            35.054835,
+                            0
+                        ],
+                        [
+                            -106.592639,
+                            35.054845,
+                            0
+                        ],
+                        [
+                            -106.59265,
+                            35.054841,
+                            0
+                        ],
+                        [
+                            -106.592644,
+                            35.054832,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            1971.2
+                        ],
+                        [
+                            3987.2,
+                            1996.8
+                        ],
+                        [
+                            4012.8,
+                            1996.8
+                        ],
+                        [
+                            4012.8,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59264130061322,
+                "center_latitude": 35.05483844852941,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.546189+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59298304748181,
+                35.055500280801795,
+                -106.59291325384483,
+                35.05555336132696
+            ],
+            "id": "a7e961af80b2f6c3bac0f29946689252",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592957,
+                            35.0555,
+                            0
+                        ],
+                        [
+                            -106.592913,
+                            35.055515,
+                            0
+                        ],
+                        [
+                            -106.592939,
+                            35.055553,
+                            0
+                        ],
+                        [
+                            -106.592983,
+                            35.055539,
+                            0
+                        ],
+                        [
+                            -106.592957,
+                            35.0555,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            2220.8
+                        ],
+                        [
+                            5676.8,
+                            2323.2
+                        ],
+                        [
+                            5779.2,
+                            2323.2
+                        ],
+                        [
+                            5779.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59294815066332,
+                "center_latitude": 35.055526821064376,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.315818+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5930908753719,
+                35.05546433817176,
+                -106.59305425954726,
+                35.05550635942615
+            ],
+            "id": "5777e0079ebc16d01db3b43272bd1f0a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593065,
+                            35.055464,
+                            0
+                        ],
+                        [
+                            -106.593054,
+                            35.055468,
+                            0
+                        ],
+                        [
+                            -106.59308,
+                            35.055506,
+                            0
+                        ],
+                        [
+                            -106.593091,
+                            35.055503,
+                            0
+                        ],
+                        [
+                            -106.593065,
+                            35.055464,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            1971.2
+                        ],
+                        [
+                            5676.8,
+                            1996.8
+                        ],
+                        [
+                            5779.2,
+                            1996.8
+                        ],
+                        [
+                            5779.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59307256745959,
+                "center_latitude": 35.05548534879895,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.006797+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59220893578895,
+                35.055099438128586,
+                -106.59213914215196,
+                35.05515251865374
+            ],
+            "id": "702e80d16b8b3fd14080fb6ce9d854eb",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592183,
+                            35.055099,
+                            0
+                        ],
+                        [
+                            -106.592139,
+                            35.055114,
+                            0
+                        ],
+                        [
+                            -106.592165,
+                            35.055153,
+                            0
+                        ],
+                        [
+                            -106.592209,
+                            35.055138,
+                            0
+                        ],
+                        [
+                            -106.592183,
+                            35.055099,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            3180.8
+                        ],
+                        [
+                            4236.8,
+                            3283.2
+                        ],
+                        [
+                            4339.2,
+                            3283.2
+                        ],
+                        [
+                            4339.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59217403897046,
+                "center_latitude": 35.05512597839117,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.802709+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59206518017349,
+                35.054883804705405,
+                -106.59199538653651,
+                35.05493688523057
+            ],
+            "id": "ef0863850587fba45d60ecc1197e98bc",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59204,
+                            35.054884,
+                            0
+                        ],
+                        [
+                            -106.591995,
+                            35.054899,
+                            0
+                        ],
+                        [
+                            -106.592021,
+                            35.054937,
+                            0
+                        ],
+                        [
+                            -106.592065,
+                            35.054922,
+                            0
+                        ],
+                        [
+                            -106.59204,
+                            35.054884,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            3180.8
+                        ],
+                        [
+                            3660.8,
+                            3283.2
+                        ],
+                        [
+                            3763.2,
+                            3283.2
+                        ],
+                        [
+                            3763.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.592030283355,
+                "center_latitude": 35.054910344967986,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.687075+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59349457601704,
+                35.05467089138588,
+                -106.59342478238007,
+                35.054723971911045
+            ],
+            "id": "35518d313a7c048f7061dbf96f4281d8",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593469,
+                            35.054671,
+                            0
+                        ],
+                        [
+                            -106.593425,
+                            35.054686,
+                            0
+                        ],
+                        [
+                            -106.59345,
+                            35.054724,
+                            0
+                        ],
+                        [
+                            -106.593495,
+                            35.054709,
+                            0
+                        ],
+                        [
+                            -106.593469,
+                            35.054671,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            204.8
+                        ],
+                        [
+                            4236.8,
+                            307.2
+                        ],
+                        [
+                            4339.2,
+                            307.2
+                        ],
+                        [
+                            4339.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59345967919856,
+                "center_latitude": 35.054697431648464,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.667409+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59256832482758,
+                35.05563852168654,
+                -106.5924985311906,
+                35.055691602211695
+            ],
+            "id": "e83d3a8d38caf69cbcc8333c66add256",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592543,
+                            35.055639,
+                            0
+                        ],
+                        [
+                            -106.592499,
+                            35.055653,
+                            0
+                        ],
+                        [
+                            -106.592524,
+                            35.055692,
+                            0
+                        ],
+                        [
+                            -106.592568,
+                            35.055677,
+                            0
+                        ],
+                        [
+                            -106.592543,
+                            35.055639,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            3180.8
+                        ],
+                        [
+                            5676.8,
+                            3283.2
+                        ],
+                        [
+                            5779.2,
+                            3283.2
+                        ],
+                        [
+                            5779.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59253342800909,
+                "center_latitude": 35.055665061949114,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.006478+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59290996984753,
+                35.053822733254705,
+                -106.59285934362595,
+                35.05384706265678
+            ],
+            "id": "4c56934917daf212aa968762e07bdf20",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592904,
+                            35.053823,
+                            0
+                        ],
+                        [
+                            -106.592859,
+                            35.053837,
+                            0
+                        ],
+                        [
+                            -106.592866,
+                            35.053847,
+                            0
+                        ],
+                        [
+                            -106.59291,
+                            35.053832,
+                            0
+                        ],
+                        [
+                            -106.592904,
+                            35.053823,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            204.8
+                        ],
+                        [
+                            1971.2,
+                            307.2
+                        ],
+                        [
+                            1996.8,
+                            307.2
+                        ],
+                        [
+                            1996.8,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59288465673674,
+                "center_latitude": 35.053834897955745,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.446702+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59299143136295,
+                35.053916174404755,
+                -106.59292163772598,
+                35.05396925492991
+            ],
+            "id": "be5f5870340dddc0b73a6bb5f9b7fb8e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592966,
+                            35.053916,
+                            0
+                        ],
+                        [
+                            -106.592922,
+                            35.053931,
+                            0
+                        ],
+                        [
+                            -106.592947,
+                            35.053969,
+                            0
+                        ],
+                        [
+                            -106.592991,
+                            35.053955,
+                            0
+                        ],
+                        [
+                            -106.592966,
+                            35.053916,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            204.8
+                        ],
+                        [
+                            2220.8,
+                            307.2
+                        ],
+                        [
+                            2323.2,
+                            307.2
+                        ],
+                        [
+                            2323.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59295653454447,
+                "center_latitude": 35.053942714667336,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.346600+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5927756861547,
+                35.05556940124416,
+                -106.59270589251771,
+                35.055622481769326
+            ],
+            "id": "bfff1bcb2b4158bb8d0d6947686a949b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59275,
+                            35.055569,
+                            0
+                        ],
+                        [
+                            -106.592706,
+                            35.055584,
+                            0
+                        ],
+                        [
+                            -106.592731,
+                            35.055622,
+                            0
+                        ],
+                        [
+                            -106.592776,
+                            35.055608,
+                            0
+                        ],
+                        [
+                            -106.59275,
+                            35.055569,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            2700.8
+                        ],
+                        [
+                            5676.8,
+                            2803.2
+                        ],
+                        [
+                            5779.2,
+                            2803.2
+                        ],
+                        [
+                            5779.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59274078933622,
+                "center_latitude": 35.055595941506745,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.256563+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59191315246197,
+                35.05427560070508,
+                -106.59184335882499,
+                35.054328681230245
+            ],
+            "id": "eec754d03556cc0e85905ba8d1d4ab2a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591888,
+                            35.054276,
+                            0
+                        ],
+                        [
+                            -106.591843,
+                            35.05429,
+                            0
+                        ],
+                        [
+                            -106.591869,
+                            35.054329,
+                            0
+                        ],
+                        [
+                            -106.591913,
+                            35.054314,
+                            0
+                        ],
+                        [
+                            -106.591888,
+                            35.054276,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            2700.8
+                        ],
+                        [
+                            2220.8,
+                            2803.2
+                        ],
+                        [
+                            2323.2,
+                            2803.2
+                        ],
+                        [
+                            2323.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59187825564348,
+                "center_latitude": 35.054302140967664,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.397365+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59183169094653,
+                35.05418215955504,
+                -106.59178106472496,
+                35.05420648895711
+            ],
+            "id": "af1db86e9d09b8b86b23d6b9e6c7f30e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591825,
+                            35.054182,
+                            0
+                        ],
+                        [
+                            -106.591781,
+                            35.054197,
+                            0
+                        ],
+                        [
+                            -106.591787,
+                            35.054206,
+                            0
+                        ],
+                        [
+                            -106.591832,
+                            35.054192,
+                            0
+                        ],
+                        [
+                            -106.591825,
+                            35.054182,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            2700.8
+                        ],
+                        [
+                            1971.2,
+                            2803.2
+                        ],
+                        [
+                            1996.8,
+                            2803.2
+                        ],
+                        [
+                            1996.8,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59180637783575,
+                "center_latitude": 35.05419432425607,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.840086+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5928632511356,
+                35.05532058628248,
+                -106.59279345749862,
+                35.05537366680764
+            ],
+            "id": "b645ff29145b2369e40a279def7a3b8f",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592838,
+                            35.055321,
+                            0
+                        ],
+                        [
+                            -106.592793,
+                            35.055335,
+                            0
+                        ],
+                        [
+                            -106.592819,
+                            35.055374,
+                            0
+                        ],
+                        [
+                            -106.592863,
+                            35.055359,
+                            0
+                        ],
+                        [
+                            -106.592838,
+                            35.055321,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            2220.8
+                        ],
+                        [
+                            5196.8,
+                            2323.2
+                        ],
+                        [
+                            5299.2,
+                            2323.2
+                        ],
+                        [
+                            5299.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5928283543171,
+                "center_latitude": 35.05534712654506,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.243877+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59297107902569,
+                35.05528464365244,
+                -106.59293446320105,
+                35.05532666490682
+            ],
+            "id": "93ef31a23cba338eda3f30d6068f8668",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592946,
+                            35.055285,
+                            0
+                        ],
+                        [
+                            -106.592934,
+                            35.055288,
+                            0
+                        ],
+                        [
+                            -106.59296,
+                            35.055327,
+                            0
+                        ],
+                        [
+                            -106.592971,
+                            35.055323,
+                            0
+                        ],
+                        [
+                            -106.592946,
+                            35.055285,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            1971.2
+                        ],
+                        [
+                            5196.8,
+                            1996.8
+                        ],
+                        [
+                            5299.2,
+                            1996.8
+                        ],
+                        [
+                            5299.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59295277111337,
+                "center_latitude": 35.055305654279636,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.972691+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59243295309328,
+                35.05383878186632,
+                -106.5923631594563,
+                35.053891862391474
+            ],
+            "id": "35eb9c3eb9b7e19f1f23e4c980663d4b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592407,
+                            35.053839,
+                            0
+                        ],
+                        [
+                            -106.592363,
+                            35.053854,
+                            0
+                        ],
+                        [
+                            -106.592389,
+                            35.053892,
+                            0
+                        ],
+                        [
+                            -106.592433,
+                            35.053877,
+                            0
+                        ],
+                        [
+                            -106.592407,
+                            35.053839,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            1164.8
+                        ],
+                        [
+                            1644.8,
+                            1267.2
+                        ],
+                        [
+                            1747.2,
+                            1267.2
+                        ],
+                        [
+                            1747.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59239805627479,
+                "center_latitude": 35.05386532212889,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.953996+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59203294880818,
+                35.0544552952244,
+                -106.5919631551712,
+                35.05450837574956
+            ],
+            "id": "9df727d256a8d63c8b48d9e2e63a489b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592007,
+                            35.054455,
+                            0
+                        ],
+                        [
+                            -106.591963,
+                            35.05447,
+                            0
+                        ],
+                        [
+                            -106.591989,
+                            35.054508,
+                            0
+                        ],
+                        [
+                            -106.592033,
+                            35.054494,
+                            0
+                        ],
+                        [
+                            -106.592007,
+                            35.054455,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            2700.8
+                        ],
+                        [
+                            2700.8,
+                            2803.2
+                        ],
+                        [
+                            2803.2,
+                            2803.2
+                        ],
+                        [
+                            2803.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59199805198969,
+                "center_latitude": 35.05448183548698,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.460534+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59278407003585,
+                35.053985294847124,
+                -106.59271427639887,
+                35.05403837537229
+            ],
+            "id": "7375813aa0f7a944664872cecf853214",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592759,
+                            35.053985,
+                            0
+                        ],
+                        [
+                            -106.592714,
+                            35.054,
+                            0
+                        ],
+                        [
+                            -106.59274,
+                            35.054038,
+                            0
+                        ],
+                        [
+                            -106.592784,
+                            35.054024,
+                            0
+                        ],
+                        [
+                            -106.592759,
+                            35.053985,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            684.8
+                        ],
+                        [
+                            2220.8,
+                            787.2
+                        ],
+                        [
+                            2323.2,
+                            787.2
+                        ],
+                        [
+                            2323.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59274917321736,
+                "center_latitude": 35.054011835109705,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.557403+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59228092538176,
+                35.053230577865996,
+                -106.59221113174479,
+                35.05328365839115
+            ],
+            "id": "c1366de6da46fd4c360acaaa9e1a53d9",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592255,
+                            35.053231,
+                            0
+                        ],
+                        [
+                            -106.592211,
+                            35.053245,
+                            0
+                        ],
+                        [
+                            -106.592237,
+                            35.053284,
+                            0
+                        ],
+                        [
+                            -106.592281,
+                            35.053269,
+                            0
+                        ],
+                        [
+                            -106.592255,
+                            35.053231,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            684.8
+                        ],
+                        [
+                            204.8,
+                            787.2
+                        ],
+                        [
+                            307.2,
+                            787.2
+                        ],
+                        [
+                            307.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59224602856327,
+                "center_latitude": 35.05325711812857,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.508593+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59302366272829,
+                35.05434468388576,
+                -106.59295386909129,
+                35.054397764410915
+            ],
+            "id": "ebcad85b08ff81aa0f3ebe2fd395f903",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592998,
+                            35.054345,
+                            0
+                        ],
+                        [
+                            -106.592954,
+                            35.054359,
+                            0
+                        ],
+                        [
+                            -106.592979,
+                            35.054398,
+                            0
+                        ],
+                        [
+                            -106.593024,
+                            35.054383,
+                            0
+                        ],
+                        [
+                            -106.592998,
+                            35.054345,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            684.8
+                        ],
+                        [
+                            3180.8,
+                            787.2
+                        ],
+                        [
+                            3283.2,
+                            787.2
+                        ],
+                        [
+                            3283.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59298876590978,
+                "center_latitude": 35.05437122414834,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.704361+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59350153650148,
+                35.05547040810171,
+                -106.5934509102799,
+                35.055494737503786
+            ],
+            "id": "a367f0f16aec5ecb1b747d66ff959630",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593495,
+                            35.05547,
+                            0
+                        ],
+                        [
+                            -106.593451,
+                            35.055485,
+                            0
+                        ],
+                        [
+                            -106.593457,
+                            35.055495,
+                            0
+                        ],
+                        [
+                            -106.593502,
+                            35.05548,
+                            0
+                        ],
+                        [
+                            -106.593495,
+                            35.05547,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            1164.8
+                        ],
+                        [
+                            6003.2,
+                            1267.2
+                        ],
+                        [
+                            6028.8,
+                            1267.2
+                        ],
+                        [
+                            6028.8,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5934762233907,
+                "center_latitude": 35.055482572802745,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.161034+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59277781868802,
+                35.055979791527804,
+                -106.59272604441811,
+                35.05600584300235
+            ],
+            "id": "af63904ec3333557ff769c04688bcd82",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59277,
+                            35.05598,
+                            0
+                        ],
+                        [
+                            -106.592726,
+                            35.055995,
+                            0
+                        ],
+                        [
+                            -106.592734,
+                            35.056006,
+                            0
+                        ],
+                        [
+                            -106.592778,
+                            35.055991,
+                            0
+                        ],
+                        [
+                            -106.59277,
+                            35.05598,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            3180.8
+                        ],
+                        [
+                            6588.4,
+                            3283.2
+                        ],
+                        [
+                            6618.6,
+                            3283.2
+                        ],
+                        [
+                            6618.6,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59275193155307,
+                "center_latitude": 35.055992817265086,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:19.920576+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.591617369135,
+                35.05345176328158,
+                -106.59154757549803,
+                35.05350484380674
+            ],
+            "id": "b75868748cd48124266bacfa5b7f111e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591592,
+                            35.053452,
+                            0
+                        ],
+                        [
+                            -106.591548,
+                            35.053467,
+                            0
+                        ],
+                        [
+                            -106.591573,
+                            35.053505,
+                            0
+                        ],
+                        [
+                            -106.591617,
+                            35.05349,
+                            0
+                        ],
+                        [
+                            -106.591592,
+                            35.053452,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            2220.8
+                        ],
+                        [
+                            204.8,
+                            2323.2
+                        ],
+                        [
+                            307.2,
+                            2323.2
+                        ],
+                        [
+                            307.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5915824723165,
+                "center_latitude": 35.05347830354416,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.411181+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59172519702508,
+                35.053415820651544,
+                -106.59168858120044,
+                35.05345784190594
+            ],
+            "id": "1dd8a49198370da5e81f2fb8ea7f1443",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.5917,
+                            35.053416,
+                            0
+                        ],
+                        [
+                            -106.591689,
+                            35.05342,
+                            0
+                        ],
+                        [
+                            -106.591714,
+                            35.053458,
+                            0
+                        ],
+                        [
+                            -106.591725,
+                            35.053454,
+                            0
+                        ],
+                        [
+                            -106.5917,
+                            35.053416,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            1971.2
+                        ],
+                        [
+                            204.8,
+                            1996.8
+                        ],
+                        [
+                            307.2,
+                            1996.8
+                        ],
+                        [
+                            307.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59170688911277,
+                "center_latitude": 35.05343683127874,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.478901+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59208458606372,
+                35.0539549042095,
+                -106.59204797023908,
+                35.05399692546388
+            ],
+            "id": "412287232c3e72943dc199e811151b5c",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592059,
+                            35.053955,
+                            0
+                        ],
+                        [
+                            -106.592048,
+                            35.053959,
+                            0
+                        ],
+                        [
+                            -106.592074,
+                            35.053997,
+                            0
+                        ],
+                        [
+                            -106.592085,
+                            35.053993,
+                            0
+                        ],
+                        [
+                            -106.592059,
+                            35.053955,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            1971.2
+                        ],
+                        [
+                            1644.8,
+                            1996.8
+                        ],
+                        [
+                            1747.2,
+                            1996.8
+                        ],
+                        [
+                            1747.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59206627815142,
+                "center_latitude": 35.05397591483669,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.532317+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59197675817363,
+                35.05399084683953,
+                -106.59190696453665,
+                35.05404392736469
+            ],
+            "id": "24148fbfb8d3172734a60bad70acb17b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591951,
+                            35.053991,
+                            0
+                        ],
+                        [
+                            -106.591907,
+                            35.054006,
+                            0
+                        ],
+                        [
+                            -106.591933,
+                            35.054044,
+                            0
+                        ],
+                        [
+                            -106.591977,
+                            35.054029,
+                            0
+                        ],
+                        [
+                            -106.591951,
+                            35.053991,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            2220.8
+                        ],
+                        [
+                            1644.8,
+                            2323.2
+                        ],
+                        [
+                            1747.2,
+                            2323.2
+                        ],
+                        [
+                            1747.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59194186135514,
+                "center_latitude": 35.054017387102114,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.601848+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59335082040158,
+                35.0544552579627,
+                -106.59328102676461,
+                35.054508338487864
+            ],
+            "id": "cc392d194fa2b17f66b28cf157ebb979",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593325,
+                            35.054455,
+                            0
+                        ],
+                        [
+                            -106.593281,
+                            35.05447,
+                            0
+                        ],
+                        [
+                            -106.593307,
+                            35.054508,
+                            0
+                        ],
+                        [
+                            -106.593351,
+                            35.054494,
+                            0
+                        ],
+                        [
+                            -106.593325,
+                            35.054455,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            204.8
+                        ],
+                        [
+                            3660.8,
+                            307.2
+                        ],
+                        [
+                            3763.2,
+                            307.2
+                        ],
+                        [
+                            3763.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5933159235831,
+                "center_latitude": 35.05448179822528,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.547944+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59214688016375,
+                35.05407709648264,
+                -106.59212943175451,
+                35.05409036661393
+            ],
+            "id": "ef99ecccd43b3fb9b160282c8b912e8a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59214,
+                            35.054077,
+                            0
+                        ],
+                        [
+                            -106.592129,
+                            35.054081,
+                            0
+                        ],
+                        [
+                            -106.592136,
+                            35.05409,
+                            0
+                        ],
+                        [
+                            -106.592147,
+                            35.054087,
+                            0
+                        ],
+                        [
+                            -106.59214,
+                            35.054077,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            1971.2
+                        ],
+                        [
+                            1971.2,
+                            1996.8
+                        ],
+                        [
+                            1996.8,
+                            1996.8
+                        ],
+                        [
+                            1996.8,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59213815595913,
+                "center_latitude": 35.05408373154828,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.538841+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59203905227365,
+                35.054113039112664,
+                -106.59198842605208,
+                35.05413736851474
+            ],
+            "id": "1b9de9e9f133e345019fa06c4cc58f49",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592033,
+                            35.054113,
+                            0
+                        ],
+                        [
+                            -106.591988,
+                            35.054128,
+                            0
+                        ],
+                        [
+                            -106.591995,
+                            35.054137,
+                            0
+                        ],
+                        [
+                            -106.592039,
+                            35.054123,
+                            0
+                        ],
+                        [
+                            -106.592033,
+                            35.054113,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            2220.8
+                        ],
+                        [
+                            1971.2,
+                            2323.2
+                        ],
+                        [
+                            1996.8,
+                            2323.2
+                        ],
+                        [
+                            1996.8,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59201373916288,
+                "center_latitude": 35.054125203813705,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.572767+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59222834167919,
+                35.05417053763268,
+                -106.59219172585453,
+                35.05421255888706
+            ],
+            "id": "f5b21a4d57f365c303b2ff1f66ad2241",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592203,
+                            35.054171,
+                            0
+                        ],
+                        [
+                            -106.592192,
+                            35.054174,
+                            0
+                        ],
+                        [
+                            -106.592217,
+                            35.054213,
+                            0
+                        ],
+                        [
+                            -106.592228,
+                            35.054209,
+                            0
+                        ],
+                        [
+                            -106.592203,
+                            35.054171,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            1971.2
+                        ],
+                        [
+                            2220.8,
+                            1996.8
+                        ],
+                        [
+                            2323.2,
+                            1996.8
+                        ],
+                        [
+                            2323.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59221003376686,
+                "center_latitude": 35.05419154825987,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.477221+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59212051378908,
+                35.054206480262714,
+                -106.5920507201521,
+                35.05425956078787
+            ],
+            "id": "2df41f71db5cdaa4ef70e4b243d27b40",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592095,
+                            35.054206,
+                            0
+                        ],
+                        [
+                            -106.592051,
+                            35.054221,
+                            0
+                        ],
+                        [
+                            -106.592076,
+                            35.05426,
+                            0
+                        ],
+                        [
+                            -106.592121,
+                            35.054245,
+                            0
+                        ],
+                        [
+                            -106.592095,
+                            35.054206,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            2220.8
+                        ],
+                        [
+                            2220.8,
+                            2323.2
+                        ],
+                        [
+                            2323.2,
+                            2323.2
+                        ],
+                        [
+                            2323.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59208561697059,
+                "center_latitude": 35.054233020525295,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.721494+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59137350951283,
+                35.054191929726464,
+                -106.59131313353613,
+                35.05424187103153
+            ],
+            "id": "34e8817c0f306ff5450f740fbf68050e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591348,
+                            35.054192,
+                            0
+                        ],
+                        [
+                            -106.591313,
+                            35.054204,
+                            0
+                        ],
+                        [
+                            -106.591339,
+                            35.054242,
+                            0
+                        ],
+                        [
+                            -106.591374,
+                            35.05423,
+                            0
+                        ],
+                        [
+                            -106.591348,
+                            35.054192,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            3617.2
+                        ],
+                        [
+                            1644.8,
+                            3697.8
+                        ],
+                        [
+                            1747.2,
+                            3697.8
+                        ],
+                        [
+                            1747.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59134332152448,
+                "center_latitude": 35.054216900379004,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.676896+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59257670870873,
+                35.05405441528949,
+                -106.59250691507175,
+                35.054107495814655
+            ],
+            "id": "f098ddc34f890da4b491df1be7617599",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592551,
+                            35.054054,
+                            0
+                        ],
+                        [
+                            -106.592507,
+                            35.054069,
+                            0
+                        ],
+                        [
+                            -106.592532,
+                            35.054107,
+                            0
+                        ],
+                        [
+                            -106.592577,
+                            35.054093,
+                            0
+                        ],
+                        [
+                            -106.592551,
+                            35.054054,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            1164.8
+                        ],
+                        [
+                            2220.8,
+                            1267.2
+                        ],
+                        [
+                            2323.2,
+                            1267.2
+                        ],
+                        [
+                            2323.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59254181189024,
+                "center_latitude": 35.054080955552074,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.807555+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5924952471933,
+                35.05396097413945,
+                -106.59244462097172,
+                35.053985303541516
+            ],
+            "id": "7d495f88421ae544cb22a50de76a7b17",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592489,
+                            35.053961,
+                            0
+                        ],
+                        [
+                            -106.592445,
+                            35.053976,
+                            0
+                        ],
+                        [
+                            -106.592451,
+                            35.053985,
+                            0
+                        ],
+                        [
+                            -106.592495,
+                            35.053971,
+                            0
+                        ],
+                        [
+                            -106.592489,
+                            35.053961,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            1164.8
+                        ],
+                        [
+                            1971.2,
+                            1267.2
+                        ],
+                        [
+                            1996.8,
+                            1267.2
+                        ],
+                        [
+                            1996.8,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59246993408252,
+                "center_latitude": 35.05397313884048,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.983134+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59143580361288,
+                35.054314121999596,
+                -106.59139459505155,
+                35.05433531218158
+            ],
+            "id": "efa4a6b4af1528ed33372471c889abac",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591429,
+                            35.054314,
+                            0
+                        ],
+                        [
+                            -106.591395,
+                            35.054326,
+                            0
+                        ],
+                        [
+                            -106.591401,
+                            35.054335,
+                            0
+                        ],
+                        [
+                            -106.591436,
+                            35.054324,
+                            0
+                        ],
+                        [
+                            -106.591429,
+                            35.054314,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            3617.2
+                        ],
+                        [
+                            1971.2,
+                            3697.8
+                        ],
+                        [
+                            1996.8,
+                            3697.8
+                        ],
+                        [
+                            1996.8,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5914151993322,
+                "center_latitude": 35.05432471709059,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.693369+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59151726512829,
+                35.054407563149645,
+                -106.59145688915159,
+                35.05445750445471
+            ],
+            "id": "46be1236362d5bcff8c5ef03c14367d5",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591492,
+                            35.054408,
+                            0
+                        ],
+                        [
+                            -106.591457,
+                            35.054419,
+                            0
+                        ],
+                        [
+                            -106.591482,
+                            35.054458,
+                            0
+                        ],
+                        [
+                            -106.591517,
+                            35.054446,
+                            0
+                        ],
+                        [
+                            -106.591492,
+                            35.054408,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            3617.2
+                        ],
+                        [
+                            2220.8,
+                            3697.8
+                        ],
+                        [
+                            2323.2,
+                            3697.8
+                        ],
+                        [
+                            2323.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59148707713993,
+                "center_latitude": 35.05443253380218,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.028432+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59283798025471,
+                35.0556915935173,
+                -106.59278735403313,
+                35.05571592291937
+            ],
+            "id": "c2118bd425bae0355268bcc5174de4ae",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592832,
+                            35.055692,
+                            0
+                        ],
+                        [
+                            -106.592787,
+                            35.055706,
+                            0
+                        ],
+                        [
+                            -106.592794,
+                            35.055716,
+                            0
+                        ],
+                        [
+                            -106.592838,
+                            35.055701,
+                            0
+                        ],
+                        [
+                            -106.592832,
+                            35.055692,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            2700.8
+                        ],
+                        [
+                            6003.2,
+                            2803.2
+                        ],
+                        [
+                            6028.8,
+                            2803.2
+                        ],
+                        [
+                            6028.8,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59281266714393,
+                "center_latitude": 35.055703758218336,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.282522+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59281630140116,
+                35.05441380432813,
+                -106.59274650776418,
+                35.05446688485329
+            ],
+            "id": "3d5b43cc97481a5ddd03ccb5939ad2e7",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592791,
+                            35.054414,
+                            0
+                        ],
+                        [
+                            -106.592747,
+                            35.054429,
+                            0
+                        ],
+                        [
+                            -106.592772,
+                            35.054467,
+                            0
+                        ],
+                        [
+                            -106.592816,
+                            35.054452,
+                            0
+                        ],
+                        [
+                            -106.592791,
+                            35.054414,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            1164.8
+                        ],
+                        [
+                            3180.8,
+                            1267.2
+                        ],
+                        [
+                            3283.2,
+                            1267.2
+                        ],
+                        [
+                            3283.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59278140458267,
+                "center_latitude": 35.05444034459071,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.916626+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59279103052027,
+                35.05478481156295,
+                -106.5927404042987,
+                35.05480914096502
+            ],
+            "id": "5380865f873926da9397ed5c83760756",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592785,
+                            35.054785,
+                            0
+                        ],
+                        [
+                            -106.59274,
+                            35.0548,
+                            0
+                        ],
+                        [
+                            -106.592747,
+                            35.054809,
+                            0
+                        ],
+                        [
+                            -106.592791,
+                            35.054794,
+                            0
+                        ],
+                        [
+                            -106.592785,
+                            35.054785,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            1644.8
+                        ],
+                        [
+                            3987.2,
+                            1747.2
+                        ],
+                        [
+                            4012.8,
+                            1747.2
+                        ],
+                        [
+                            4012.8,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59276571740949,
+                "center_latitude": 35.05479697626399,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.257571+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59152980415409,
+                35.053700578243266,
+                -106.59146001051711,
+                35.053753658768436
+            ],
+            "id": "0de3c70335a2ca098c5c22d17b46c1ad",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591504,
+                            35.053701,
+                            0
+                        ],
+                        [
+                            -106.59146,
+                            35.053715,
+                            0
+                        ],
+                        [
+                            -106.591486,
+                            35.053754,
+                            0
+                        ],
+                        [
+                            -106.59153,
+                            35.053739,
+                            0
+                        ],
+                        [
+                            -106.591504,
+                            35.053701,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            2700.8
+                        ],
+                        [
+                            684.8,
+                            2803.2
+                        ],
+                        [
+                            787.2,
+                            2803.2
+                        ],
+                        [
+                            787.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5914949073356,
+                "center_latitude": 35.05372711850585,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.741194+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59219336040086,
+                35.05347939282768,
+                -106.59212356676387,
+                35.05353247335284
+            ],
+            "id": "3e3ad7702e9148a40ad0c71f69c14da3",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592168,
+                            35.053479,
+                            0
+                        ],
+                        [
+                            -106.592124,
+                            35.053494,
+                            0
+                        ],
+                        [
+                            -106.592149,
+                            35.053532,
+                            0
+                        ],
+                        [
+                            -106.592193,
+                            35.053518,
+                            0
+                        ],
+                        [
+                            -106.592168,
+                            35.053479,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            1164.8
+                        ],
+                        [
+                            684.8,
+                            1267.2
+                        ],
+                        [
+                            787.2,
+                            1267.2
+                        ],
+                        [
+                            787.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59215846358236,
+                "center_latitude": 35.053505933090264,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.847897+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59240072172797,
+                35.05341027238531,
+                -106.59233092809099,
+                35.05346335291047
+            ],
+            "id": "71f3e3b19030ba11b9085f2fec0addc3",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592375,
+                            35.05341,
+                            0
+                        ],
+                        [
+                            -106.592331,
+                            35.053425,
+                            0
+                        ],
+                        [
+                            -106.592356,
+                            35.053463,
+                            0
+                        ],
+                        [
+                            -106.592401,
+                            35.053449,
+                            0
+                        ],
+                        [
+                            -106.592375,
+                            35.05341,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            684.8
+                        ],
+                        [
+                            684.8,
+                            787.2
+                        ],
+                        [
+                            787.2,
+                            787.2
+                        ],
+                        [
+                            787.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59236582490948,
+                "center_latitude": 35.05343681264789,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.570472+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59341311450162,
+                35.05457745023584,
+                -106.59336248828004,
+                35.054601779637906
+            ],
+            "id": "0eb10f1e60aaa45be51c68821adf01cf",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593407,
+                            35.054577,
+                            0
+                        ],
+                        [
+                            -106.593362,
+                            35.054592,
+                            0
+                        ],
+                        [
+                            -106.593369,
+                            35.054602,
+                            0
+                        ],
+                        [
+                            -106.593413,
+                            35.054587,
+                            0
+                        ],
+                        [
+                            -106.593407,
+                            35.054577,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            204.8
+                        ],
+                        [
+                            3987.2,
+                            307.2
+                        ],
+                        [
+                            4012.8,
+                            307.2
+                        ],
+                        [
+                            4012.8,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59338780139083,
+                "center_latitude": 35.05458961493687,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.514609+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5910141204742,
+                35.05365284616851,
+                -106.5909537444975,
+                35.05370278747358
+            ],
+            "id": "d9b495b031434eeb566fa1c4484585e4",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.590989,
+                            35.053653,
+                            0
+                        ],
+                        [
+                            -106.590954,
+                            35.053664,
+                            0
+                        ],
+                        [
+                            -106.590979,
+                            35.053703,
+                            0
+                        ],
+                        [
+                            -106.591014,
+                            35.053691,
+                            0
+                        ],
+                        [
+                            -106.590989,
+                            35.053653,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            3617.2
+                        ],
+                        [
+                            204.8,
+                            3697.8
+                        ],
+                        [
+                            307.2,
+                            3697.8
+                        ],
+                        [
+                            307.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59098393248584,
+                "center_latitude": 35.05367781682104,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.523939+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59272873642026,
+                35.054662619289815,
+                -106.59265894278327,
+                35.05471569981498
+            ],
+            "id": "a7f79b95c84c64631c6f3e09d5714f0e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592703,
+                            35.054663,
+                            0
+                        ],
+                        [
+                            -106.592659,
+                            35.054677,
+                            0
+                        ],
+                        [
+                            -106.592684,
+                            35.054716,
+                            0
+                        ],
+                        [
+                            -106.592729,
+                            35.054701,
+                            0
+                        ],
+                        [
+                            -106.592703,
+                            35.054663,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            1644.8
+                        ],
+                        [
+                            3660.8,
+                            1747.2
+                        ],
+                        [
+                            3763.2,
+                            1747.2
+                        ],
+                        [
+                            3763.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59269383960176,
+                "center_latitude": 35.054689159552396,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.238319+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59214020612859,
+                35.05534197465009,
+                -106.59207983015189,
+                35.05539191595516
+            ],
+            "id": "d94057419c275f9b9bcb9cef5aa57ebd",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592115,
+                            35.055342,
+                            0
+                        ],
+                        [
+                            -106.59208,
+                            35.055354,
+                            0
+                        ],
+                        [
+                            -106.592105,
+                            35.055392,
+                            0
+                        ],
+                        [
+                            -106.59214,
+                            35.05538,
+                            0
+                        ],
+                        [
+                            -106.592115,
+                            35.055342,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            3617.2
+                        ],
+                        [
+                            4716.8,
+                            3697.8
+                        ],
+                        [
+                            4819.2,
+                            3697.8
+                        ],
+                        [
+                            4819.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59211001814023,
+                "center_latitude": 35.05536694530262,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.477504+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59284767574749,
+                35.05370054098157,
+                -106.59277788211052,
+                35.053753621506736
+            ],
+            "id": "621af6248f7dde258947873cdd28aba2",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592822,
+                            35.053701,
+                            0
+                        ],
+                        [
+                            -106.592778,
+                            35.053715,
+                            0
+                        ],
+                        [
+                            -106.592803,
+                            35.053754,
+                            0
+                        ],
+                        [
+                            -106.592848,
+                            35.053739,
+                            0
+                        ],
+                        [
+                            -106.592822,
+                            35.053701,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            204.8
+                        ],
+                        [
+                            1644.8,
+                            307.2
+                        ],
+                        [
+                            1747.2,
+                            307.2
+                        ],
+                        [
+                            1747.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59281277892902,
+                "center_latitude": 35.053727081244155,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.497646+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59186620272753,
+                35.053368818750734,
+                -106.59179640909055,
+                35.053421899275904
+            ],
+            "id": "6b66f98872f127e82c46f463f98c42d8",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591841,
+                            35.053369,
+                            0
+                        ],
+                        [
+                            -106.591796,
+                            35.053384,
+                            0
+                        ],
+                        [
+                            -106.591822,
+                            35.053422,
+                            0
+                        ],
+                        [
+                            -106.591866,
+                            35.053407,
+                            0
+                        ],
+                        [
+                            -106.591841,
+                            35.053369,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            1644.8
+                        ],
+                        [
+                            204.8,
+                            1747.2
+                        ],
+                        [
+                            307.2,
+                            1747.2
+                        ],
+                        [
+                            307.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59183130590904,
+                "center_latitude": 35.053395359013315,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.046498+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59236010648152,
+                35.05456586930134,
+                -106.59229031284453,
+                35.054618949826505
+            ],
+            "id": "a9318f096ec3852a0e56a99052015182",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592335,
+                            35.054566,
+                            0
+                        ],
+                        [
+                            -106.59229,
+                            35.054581,
+                            0
+                        ],
+                        [
+                            -106.592316,
+                            35.054619,
+                            0
+                        ],
+                        [
+                            -106.59236,
+                            35.054604,
+                            0
+                        ],
+                        [
+                            -106.592335,
+                            35.054566,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            2220.8
+                        ],
+                        [
+                            3180.8,
+                            2323.2
+                        ],
+                        [
+                            3283.2,
+                            2323.2
+                        ],
+                        [
+                            3283.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59232520966302,
+                "center_latitude": 35.054592409563924,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.863474+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5924679343716,
+                35.054529926671314,
+                -106.59243131854696,
+                35.054571947925695
+            ],
+            "id": "834ae8d79255388457660bc0980e4a4d",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592442,
+                            35.05453,
+                            0
+                        ],
+                        [
+                            -106.592431,
+                            35.054534,
+                            0
+                        ],
+                        [
+                            -106.592457,
+                            35.054572,
+                            0
+                        ],
+                        [
+                            -106.592468,
+                            35.054568,
+                            0
+                        ],
+                        [
+                            -106.592442,
+                            35.05453,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            1971.2
+                        ],
+                        [
+                            3180.8,
+                            1996.8
+                        ],
+                        [
+                            3283.2,
+                            1996.8
+                        ],
+                        [
+                            3283.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59244962645928,
+                "center_latitude": 35.0545509372985,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.519744+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59331944605526,
+                35.05516852130926,
+                -106.59324965241827,
+                35.05522160183442
+            ],
+            "id": "7eb9b99d7cbe7e9d965d141dbfa00c93",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593294,
+                            35.055169,
+                            0
+                        ],
+                        [
+                            -106.59325,
+                            35.055183,
+                            0
+                        ],
+                        [
+                            -106.593275,
+                            35.055222,
+                            0
+                        ],
+                        [
+                            -106.593319,
+                            35.055207,
+                            0
+                        ],
+                        [
+                            -106.593294,
+                            35.055169,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            1164.8
+                        ],
+                        [
+                            5196.8,
+                            1267.2
+                        ],
+                        [
+                            5299.2,
+                            1267.2
+                        ],
+                        [
+                            5299.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59328454923676,
+                "center_latitude": 35.055195061571844,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.076678+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59132244282698,
+                35.05376969868564,
+                -106.59125264919,
+                35.0538227792108
+            ],
+            "id": "af00204069511fef9e66a338a74f8dbb",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591297,
+                            35.05377,
+                            0
+                        ],
+                        [
+                            -106.591253,
+                            35.053784,
+                            0
+                        ],
+                        [
+                            -106.591278,
+                            35.053823,
+                            0
+                        ],
+                        [
+                            -106.591322,
+                            35.053808,
+                            0
+                        ],
+                        [
+                            -106.591297,
+                            35.05377,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            3180.8
+                        ],
+                        [
+                            684.8,
+                            3283.2
+                        ],
+                        [
+                            787.2,
+                            3283.2
+                        ],
+                        [
+                            787.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59128754600849,
+                "center_latitude": 35.05379623894822,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:19.619294+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59232873213516,
+                35.055279132647904,
+                -106.59225893849818,
+                35.05533221317306
+            ],
+            "id": "0a8ce4bfd7714ea7885f7809a9fa9237",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592303,
+                            35.055279,
+                            0
+                        ],
+                        [
+                            -106.592259,
+                            35.055294,
+                            0
+                        ],
+                        [
+                            -106.592284,
+                            35.055332,
+                            0
+                        ],
+                        [
+                            -106.592329,
+                            35.055317,
+                            0
+                        ],
+                        [
+                            -106.592303,
+                            35.055279,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            3180.8
+                        ],
+                        [
+                            4716.8,
+                            3283.2
+                        ],
+                        [
+                            4819.2,
+                            3283.2
+                        ],
+                        [
+                            4819.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59229383531667,
+                "center_latitude": 35.055305672910485,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.857569+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59323188107435,
+                35.055417336270956,
+                -106.59316208743736,
+                35.05547041679611
+            ],
+            "id": "e3615ac3f7351a4c770dd53be06771e0",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593206,
+                            35.055417,
+                            0
+                        ],
+                        [
+                            -106.593162,
+                            35.055432,
+                            0
+                        ],
+                        [
+                            -106.593188,
+                            35.05547,
+                            0
+                        ],
+                        [
+                            -106.593232,
+                            35.055456,
+                            0
+                        ],
+                        [
+                            -106.593206,
+                            35.055417,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            1644.8
+                        ],
+                        [
+                            5676.8,
+                            1747.2
+                        ],
+                        [
+                            5779.2,
+                            1747.2
+                        ],
+                        [
+                            5779.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59319698425585,
+                "center_latitude": 35.05544387653353,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.809897+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5916496005003,
+                35.053880272762584,
+                -106.59157980686332,
+                35.053933353287746
+            ],
+            "id": "36a0609192f1727c9c0cf211b2f79888",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591624,
+                            35.05388,
+                            0
+                        ],
+                        [
+                            -106.59158,
+                            35.053895,
+                            0
+                        ],
+                        [
+                            -106.591605,
+                            35.053933,
+                            0
+                        ],
+                        [
+                            -106.59165,
+                            35.053919,
+                            0
+                        ],
+                        [
+                            -106.591624,
+                            35.05388,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            2700.8
+                        ],
+                        [
+                            1164.8,
+                            2803.2
+                        ],
+                        [
+                            1267.2,
+                            2803.2
+                        ],
+                        [
+                            1267.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59161470368181,
+                "center_latitude": 35.053906813025165,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.793529+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59170579113486,
+                35.05434472114745,
+                -106.59163599749787,
+                35.054397801672614
+            ],
+            "id": "eec6b0e55b6b7e601e94cad6faf976e1",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59168,
+                            35.054345,
+                            0
+                        ],
+                        [
+                            -106.591636,
+                            35.054359,
+                            0
+                        ],
+                        [
+                            -106.591662,
+                            35.054398,
+                            0
+                        ],
+                        [
+                            -106.591706,
+                            35.054383,
+                            0
+                        ],
+                        [
+                            -106.59168,
+                            35.054345,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            3180.8
+                        ],
+                        [
+                            2220.8,
+                            3283.2
+                        ],
+                        [
+                            2323.2,
+                            3283.2
+                        ],
+                        [
+                            2323.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59167089431637,
+                "center_latitude": 35.05437126141003,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.489360+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59175685782071,
+                35.054766952188274,
+                -106.59169648184401,
+                35.054816893493346
+            ],
+            "id": "970a78d805ea97907182ef6d7d4a15a9",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591731,
+                            35.054767,
+                            0
+                        ],
+                        [
+                            -106.591696,
+                            35.054779,
+                            0
+                        ],
+                        [
+                            -106.591722,
+                            35.054817,
+                            0
+                        ],
+                        [
+                            -106.591757,
+                            35.054805,
+                            0
+                        ],
+                        [
+                            -106.591731,
+                            35.054767,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            3617.2
+                        ],
+                        [
+                            3180.8,
+                            3697.8
+                        ],
+                        [
+                            3283.2,
+                            3697.8
+                        ],
+                        [
+                            3283.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59172666983235,
+                "center_latitude": 35.05479192284081,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.095516+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59120264648077,
+                35.053590004166324,
+                -106.59113285284378,
+                35.05364308469148
+            ],
+            "id": "985ea487e6d9c9843460119b93ed358a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591177,
+                            35.05359,
+                            0
+                        ],
+                        [
+                            -106.591133,
+                            35.053605,
+                            0
+                        ],
+                        [
+                            -106.591158,
+                            35.053643,
+                            0
+                        ],
+                        [
+                            -106.591203,
+                            35.053628,
+                            0
+                        ],
+                        [
+                            -106.591177,
+                            35.05359,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            3180.8
+                        ],
+                        [
+                            204.8,
+                            3283.2
+                        ],
+                        [
+                            307.2,
+                            3283.2
+                        ],
+                        [
+                            307.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59116774966228,
+                "center_latitude": 35.05361654442891,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:19.556705+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5922600024748,
+                35.055521669169416,
+                -106.59219962649811,
+                35.05557161047448
+            ],
+            "id": "cb156d9778ac97d6c199ab67b9d79037",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592234,
+                            35.055522,
+                            0
+                        ],
+                        [
+                            -106.5922,
+                            35.055533,
+                            0
+                        ],
+                        [
+                            -106.592225,
+                            35.055572,
+                            0
+                        ],
+                        [
+                            -106.59226,
+                            35.05556,
+                            0
+                        ],
+                        [
+                            -106.592234,
+                            35.055522,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            3617.2
+                        ],
+                        [
+                            5196.8,
+                            3697.8
+                        ],
+                        [
+                            5299.2,
+                            3697.8
+                        ],
+                        [
+                            5299.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59222981448644,
+                "center_latitude": 35.05554663982194,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.526601+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59207356405464,
+                35.053299698308365,
+                -106.59200377041766,
+                35.05335277883352
+            ],
+            "id": "4258cc047aeee1764a45d5a62cdc5f88",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592048,
+                            35.0533,
+                            0
+                        ],
+                        [
+                            -106.592004,
+                            35.053314,
+                            0
+                        ],
+                        [
+                            -106.592029,
+                            35.053353,
+                            0
+                        ],
+                        [
+                            -106.592074,
+                            35.053338,
+                            0
+                        ],
+                        [
+                            -106.592048,
+                            35.0533,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            1164.8
+                        ],
+                        [
+                            204.8,
+                            1267.2
+                        ],
+                        [
+                            307.2,
+                            1267.2
+                        ],
+                        [
+                            307.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59203866723615,
+                "center_latitude": 35.053326238570946,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.780875+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59298518001513,
+                35.055910671085435,
+                -106.59293340574524,
+                35.05593672255998
+            ],
+            "id": "d7af0545a6209e1f36f41005aa589674",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592978,
+                            35.055911,
+                            0
+                        ],
+                        [
+                            -106.592933,
+                            35.055925,
+                            0
+                        ],
+                        [
+                            -106.592941,
+                            35.055937,
+                            0
+                        ],
+                        [
+                            -106.592985,
+                            35.055922,
+                            0
+                        ],
+                        [
+                            -106.592978,
+                            35.055911,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            2700.8
+                        ],
+                        [
+                            6588.4,
+                            2803.2
+                        ],
+                        [
+                            6618.6,
+                            2803.2
+                        ],
+                        [
+                            6618.6,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5929592928802,
+                "center_latitude": 35.05592369682271,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.633478+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5931434590745,
+                35.05452437840508,
+                -106.5930736654375,
+                35.05457745893023
+            ],
+            "id": "8cbb802a6420a606221a12152d509d1f",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593118,
+                            35.054524,
+                            0
+                        ],
+                        [
+                            -106.593074,
+                            35.054539,
+                            0
+                        ],
+                        [
+                            -106.593099,
+                            35.054577,
+                            0
+                        ],
+                        [
+                            -106.593143,
+                            35.054563,
+                            0
+                        ],
+                        [
+                            -106.593118,
+                            35.054524,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            684.8
+                        ],
+                        [
+                            3660.8,
+                            787.2
+                        ],
+                        [
+                            3763.2,
+                            787.2
+                        ],
+                        [
+                            3763.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59310856225599,
+                "center_latitude": 35.05455091866766,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.782232+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59269650505495,
+                35.05423410980881,
+                -106.59262671141796,
+                35.05428719033397
+            ],
+            "id": "fc2018ae7ed2d9131f642295425c24f8",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592671,
+                            35.054234,
+                            0
+                        ],
+                        [
+                            -106.592627,
+                            35.054249,
+                            0
+                        ],
+                        [
+                            -106.592652,
+                            35.054287,
+                            0
+                        ],
+                        [
+                            -106.592697,
+                            35.054272,
+                            0
+                        ],
+                        [
+                            -106.592671,
+                            35.054234,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            1164.8
+                        ],
+                        [
+                            2700.8,
+                            1267.2
+                        ],
+                        [
+                            2803.2,
+                            1267.2
+                        ],
+                        [
+                            2803.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59266160823645,
+                "center_latitude": 35.05426065007139,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.857601+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59311122770916,
+                35.05409586892407,
+                -106.59304143407219,
+                35.05414894944923
+            ],
+            "id": "b8f9f4ea6fe636908398705b322da6cd",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593086,
+                            35.054096,
+                            0
+                        ],
+                        [
+                            -106.593041,
+                            35.054111,
+                            0
+                        ],
+                        [
+                            -106.593067,
+                            35.054149,
+                            0
+                        ],
+                        [
+                            -106.593111,
+                            35.054134,
+                            0
+                        ],
+                        [
+                            -106.593086,
+                            35.054096,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            204.8
+                        ],
+                        [
+                            2700.8,
+                            307.2
+                        ],
+                        [
+                            2803.2,
+                            307.2
+                        ],
+                        [
+                            2803.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59307633089068,
+                "center_latitude": 35.05412240918665,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.467509+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59352680738236,
+                35.05509940086689,
+                -106.59345701374538,
+                35.05515248139205
+            ],
+            "id": "d8f4079404967da767665702bbdaf8fa",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593501,
+                            35.055099,
+                            0
+                        ],
+                        [
+                            -106.593457,
+                            35.055114,
+                            0
+                        ],
+                        [
+                            -106.593483,
+                            35.055152,
+                            0
+                        ],
+                        [
+                            -106.593527,
+                            35.055138,
+                            0
+                        ],
+                        [
+                            -106.593501,
+                            35.055099,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            684.8
+                        ],
+                        [
+                            5196.8,
+                            787.2
+                        ],
+                        [
+                            5299.2,
+                            787.2
+                        ],
+                        [
+                            5299.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59349191056387,
+                "center_latitude": 35.05512594112947,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.427572+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59244209292105,
+                35.05582355596186,
+                -106.59240088435973,
+                35.05584474614384
+            ],
+            "id": "4bf0a4b252249fd8435ef18e31c539a6",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592436,
+                            35.055824,
+                            0
+                        ],
+                        [
+                            -106.592401,
+                            35.055835,
+                            0
+                        ],
+                        [
+                            -106.592407,
+                            35.055845,
+                            0
+                        ],
+                        [
+                            -106.592442,
+                            35.055833,
+                            0
+                        ],
+                        [
+                            -106.592436,
+                            35.055824,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            3617.2
+                        ],
+                        [
+                            6003.2,
+                            3697.8
+                        ],
+                        [
+                            6028.8,
+                            3697.8
+                        ],
+                        [
+                            6028.8,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59242148864038,
+                "center_latitude": 35.05583415105285,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.607809+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59373416870946,
+                35.05503028042452,
+                -106.59366437507249,
+                35.05508336094968
+            ],
+            "id": "b0d71091daa50752c2d594cd2c069ab9",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593709,
+                            35.05503,
+                            0
+                        ],
+                        [
+                            -106.593664,
+                            35.055045,
+                            0
+                        ],
+                        [
+                            -106.59369,
+                            35.055083,
+                            0
+                        ],
+                        [
+                            -106.593734,
+                            35.055069,
+                            0
+                        ],
+                        [
+                            -106.593709,
+                            35.05503,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            204.8
+                        ],
+                        [
+                            5196.8,
+                            307.2
+                        ],
+                        [
+                            5299.2,
+                            307.2
+                        ],
+                        [
+                            5299.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59369927189098,
+                "center_latitude": 35.0550568206871,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.780499+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59222559176617,
+                35.05390790230869,
+                -106.59215579812918,
+                35.05396098283384
+            ],
+            "id": "0ab256aac084b32308245aba916ca899",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.5922,
+                            35.053908,
+                            0
+                        ],
+                        [
+                            -106.592156,
+                            35.053923,
+                            0
+                        ],
+                        [
+                            -106.592181,
+                            35.053961,
+                            0
+                        ],
+                        [
+                            -106.592226,
+                            35.053946,
+                            0
+                        ],
+                        [
+                            -106.5922,
+                            35.053908,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            1644.8
+                        ],
+                        [
+                            1644.8,
+                            1747.2
+                        ],
+                        [
+                            1747.2,
+                            1747.2
+                        ],
+                        [
+                            1747.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59219069494767,
+                "center_latitude": 35.05393444257127,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.234536+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59271208044305,
+                35.05585415510972,
+                -106.59264228680605,
+                35.055907235634876
+            ],
+            "id": "bca5cd33b15d7de6b78dce2b0692c04d",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592687,
+                            35.055854,
+                            0
+                        ],
+                        [
+                            -106.592642,
+                            35.055869,
+                            0
+                        ],
+                        [
+                            -106.592668,
+                            35.055907,
+                            0
+                        ],
+                        [
+                            -106.592712,
+                            35.055892,
+                            0
+                        ],
+                        [
+                            -106.592687,
+                            35.055854,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            3180.8
+                        ],
+                        [
+                            6252.8,
+                            3283.2
+                        ],
+                        [
+                            6355.2,
+                            3283.2
+                        ],
+                        [
+                            6355.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59267718362455,
+                "center_latitude": 35.055880695372295,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:19.884854+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.593856097589,
+                35.055620365227476,
+                -106.5938043233191,
+                35.055646416702025
+            ],
+            "id": "2c9ca5ff87e7d62888ce36c367864fe1",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593849,
+                            35.05562,
+                            0
+                        ],
+                        [
+                            -106.593804,
+                            35.055635,
+                            0
+                        ],
+                        [
+                            -106.593812,
+                            35.055646,
+                            0
+                        ],
+                        [
+                            -106.593856,
+                            35.055632,
+                            0
+                        ],
+                        [
+                            -106.593849,
+                            35.05562,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            684.8
+                        ],
+                        [
+                            6588.4,
+                            787.2
+                        ],
+                        [
+                            6618.6,
+                            787.2
+                        ],
+                        [
+                            6618.6,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59383021045406,
+                "center_latitude": 35.05563339096475,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.299767+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59241629711606,
+                35.05503031768622,
+                -106.59234650347908,
+                35.05508339821137
+            ],
+            "id": "9261f14c03df610444d40fc8840f3d94",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592391,
+                            35.05503,
+                            0
+                        ],
+                        [
+                            -106.592347,
+                            35.055045,
+                            0
+                        ],
+                        [
+                            -106.592372,
+                            35.055083,
+                            0
+                        ],
+                        [
+                            -106.592416,
+                            35.055069,
+                            0
+                        ],
+                        [
+                            -106.592391,
+                            35.05503,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            2700.8
+                        ],
+                        [
+                            4236.8,
+                            2803.2
+                        ],
+                        [
+                            4339.2,
+                            2803.2
+                        ],
+                        [
+                            4339.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59238140029757,
+                "center_latitude": 35.05505685794879,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.071618+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59340701103615,
+                35.054919706347576,
+                -106.59333721739917,
+                35.05497278687273
+            ],
+            "id": "bc797f2c342a604db9243518ec594f3f",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593381,
+                            35.05492,
+                            0
+                        ],
+                        [
+                            -106.593337,
+                            35.054934,
+                            0
+                        ],
+                        [
+                            -106.593363,
+                            35.054973,
+                            0
+                        ],
+                        [
+                            -106.593407,
+                            35.054958,
+                            0
+                        ],
+                        [
+                            -106.593381,
+                            35.05492,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            684.8
+                        ],
+                        [
+                            4716.8,
+                            787.2
+                        ],
+                        [
+                            4819.2,
+                            787.2
+                        ],
+                        [
+                            4819.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59337211421766,
+                "center_latitude": 35.05494624661015,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.358669+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59248828670887,
+                35.05316145742362,
+                -106.59241849307189,
+                35.05321453794878
+            ],
+            "id": "bfeb854fcd4a0553ae2622a8c19183da",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592463,
+                            35.053161,
+                            0
+                        ],
+                        [
+                            -106.592418,
+                            35.053176,
+                            0
+                        ],
+                        [
+                            -106.592444,
+                            35.053215,
+                            0
+                        ],
+                        [
+                            -106.592488,
+                            35.0532,
+                            0
+                        ],
+                        [
+                            -106.592463,
+                            35.053161,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            204.8
+                        ],
+                        [
+                            204.8,
+                            307.2
+                        ],
+                        [
+                            307.2,
+                            307.2
+                        ],
+                        [
+                            307.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59245338989038,
+                "center_latitude": 35.0531879976862,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.260070+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59253609346229,
+                35.05521001220553,
+                -106.59246629982529,
+                35.05526309273069
+            ],
+            "id": "4b6fd141a636eded5273acf1ddab8dc2",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592511,
+                            35.05521,
+                            0
+                        ],
+                        [
+                            -106.592466,
+                            35.055225,
+                            0
+                        ],
+                        [
+                            -106.592492,
+                            35.055263,
+                            0
+                        ],
+                        [
+                            -106.592536,
+                            35.055248,
+                            0
+                        ],
+                        [
+                            -106.592511,
+                            35.05521,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            2700.8
+                        ],
+                        [
+                            4716.8,
+                            2803.2
+                        ],
+                        [
+                            4819.2,
+                            2803.2
+                        ],
+                        [
+                            4819.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59250119664378,
+                "center_latitude": 35.05523655246811,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.129363+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5932057531745,
+                35.05464657067821,
+                -106.59315512695292,
+                35.05467090008028
+            ],
+            "id": "51bafc93e83d97e8f27d1b31bbe4e817",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593199,
+                            35.054647,
+                            0
+                        ],
+                        [
+                            -106.593155,
+                            35.054661,
+                            0
+                        ],
+                        [
+                            -106.593162,
+                            35.054671,
+                            0
+                        ],
+                        [
+                            -106.593206,
+                            35.054656,
+                            0
+                        ],
+                        [
+                            -106.593199,
+                            35.054647,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            684.8
+                        ],
+                        [
+                            3987.2,
+                            787.2
+                        ],
+                        [
+                            4012.8,
+                            787.2
+                        ],
+                        [
+                            4012.8,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59318044006372,
+                "center_latitude": 35.05465873537924,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.761554+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59162432961942,
+                35.05425127999741,
+                -106.59157370339784,
+                35.054275609399475
+            ],
+            "id": "0cde751a33ade9b15c53e3032ed7c184",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591618,
+                            35.054251,
+                            0
+                        ],
+                        [
+                            -106.591574,
+                            35.054266,
+                            0
+                        ],
+                        [
+                            -106.59158,
+                            35.054276,
+                            0
+                        ],
+                        [
+                            -106.591624,
+                            35.054261,
+                            0
+                        ],
+                        [
+                            -106.591618,
+                            35.054251,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            3180.8
+                        ],
+                        [
+                            1971.2,
+                            3283.2
+                        ],
+                        [
+                            1996.8,
+                            3283.2
+                        ],
+                        [
+                            1996.8,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59159901650864,
+                "center_latitude": 35.05426344469844,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:19.769718+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59228788586618,
+                35.05403009458182,
+                -106.5922372596446,
+                35.05405442398389
+            ],
+            "id": "9dcf3db5e44b1136c42e9e70c1977085",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592281,
+                            35.05403,
+                            0
+                        ],
+                        [
+                            -106.592237,
+                            35.054045,
+                            0
+                        ],
+                        [
+                            -106.592244,
+                            35.054054,
+                            0
+                        ],
+                        [
+                            -106.592288,
+                            35.05404,
+                            0
+                        ],
+                        [
+                            -106.592281,
+                            35.05403,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1971.2,
+                            1644.8
+                        ],
+                        [
+                            1971.2,
+                            1747.2
+                        ],
+                        [
+                            1996.8,
+                            1747.2
+                        ],
+                        [
+                            1996.8,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5922625727554,
+                "center_latitude": 35.05404225928286,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.258854+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59236934738162,
+                35.05412353573187,
+                -106.59229955374464,
+                35.054176616257024
+            ],
+            "id": "267a5cfc889a3c0c11a9116cff71c7db",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592344,
+                            35.054124,
+                            0
+                        ],
+                        [
+                            -106.5923,
+                            35.054138,
+                            0
+                        ],
+                        [
+                            -106.592325,
+                            35.054177,
+                            0
+                        ],
+                        [
+                            -106.592369,
+                            35.054162,
+                            0
+                        ],
+                        [
+                            -106.592344,
+                            35.054124,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2220.8,
+                            1644.8
+                        ],
+                        [
+                            2220.8,
+                            1747.2
+                        ],
+                        [
+                            2323.2,
+                            1747.2
+                        ],
+                        [
+                            2323.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59233445056313,
+                "center_latitude": 35.05415007599445,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.056512+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59299839184739,
+                35.054715691120585,
+                -106.59294776562581,
+                35.05474002052265
+            ],
+            "id": "aa4d4d3d59112995cbb8f1b82ee57e0e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592992,
+                            35.054716,
+                            0
+                        ],
+                        [
+                            -106.592948,
+                            35.05473,
+                            0
+                        ],
+                        [
+                            -106.592954,
+                            35.05474,
+                            0
+                        ],
+                        [
+                            -106.592998,
+                            35.054725,
+                            0
+                        ],
+                        [
+                            -106.592992,
+                            35.054716,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            1164.8
+                        ],
+                        [
+                            3987.2,
+                            1267.2
+                        ],
+                        [
+                            4012.8,
+                            1267.2
+                        ],
+                        [
+                            4012.8,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5929730787366,
+                "center_latitude": 35.054727855821625,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.995238+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59125371316662,
+                35.054012235207146,
+                -106.59119333718992,
+                35.05406217651222
+            ],
+            "id": "c00738a114901f7c53ddbc34b5358676",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591228,
+                            35.054012,
+                            0
+                        ],
+                        [
+                            -106.591193,
+                            35.054024,
+                            0
+                        ],
+                        [
+                            -106.591219,
+                            35.054062,
+                            0
+                        ],
+                        [
+                            -106.591254,
+                            35.054051,
+                            0
+                        ],
+                        [
+                            -106.591228,
+                            35.054012,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            3617.2
+                        ],
+                        [
+                            1164.8,
+                            3697.8
+                        ],
+                        [
+                            1267.2,
+                            3697.8
+                        ],
+                        [
+                            1267.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59122352517826,
+                "center_latitude": 35.05403720585968,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.618978+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59311208472813,
+                35.05523764175163,
+                -106.59304229109115,
+                35.055290722276794
+            ],
+            "id": "78d8c22281d1ed03d0ee308acdc47326",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593087,
+                            35.055238,
+                            0
+                        ],
+                        [
+                            -106.593042,
+                            35.055252,
+                            0
+                        ],
+                        [
+                            -106.593068,
+                            35.055291,
+                            0
+                        ],
+                        [
+                            -106.593112,
+                            35.055276,
+                            0
+                        ],
+                        [
+                            -106.593087,
+                            35.055238,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            1644.8
+                        ],
+                        [
+                            5196.8,
+                            1747.2
+                        ],
+                        [
+                            5299.2,
+                            1747.2
+                        ],
+                        [
+                            5299.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59307718790964,
+                "center_latitude": 35.05526418201421,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.780746+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59299228838192,
+                35.055057947232314,
+                -106.59292249474494,
+                35.05511102775748
+            ],
+            "id": "0e00aa35062c30e7f64381f7cc69e2fd",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592967,
+                            35.055058,
+                            0
+                        ],
+                        [
+                            -106.592922,
+                            35.055073,
+                            0
+                        ],
+                        [
+                            -106.592948,
+                            35.055111,
+                            0
+                        ],
+                        [
+                            -106.592992,
+                            35.055096,
+                            0
+                        ],
+                        [
+                            -106.592967,
+                            35.055058,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            1644.8
+                        ],
+                        [
+                            4716.8,
+                            1747.2
+                        ],
+                        [
+                            4819.2,
+                            1747.2
+                        ],
+                        [
+                            4819.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59295739156343,
+                "center_latitude": 35.055084487494895,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.705046+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5939162591557,
+                35.05533216721697,
+                -106.59386563293413,
+                35.05535649661904
+            ],
+            "id": "a2dde473fb8dd2bc05fe04cfb6848c0f",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59391,
+                            35.055332,
+                            0
+                        ],
+                        [
+                            -106.593866,
+                            35.055347,
+                            0
+                        ],
+                        [
+                            -106.593872,
+                            35.055356,
+                            0
+                        ],
+                        [
+                            -106.593916,
+                            35.055342,
+                            0
+                        ],
+                        [
+                            -106.59391,
+                            35.055332,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            204.8
+                        ],
+                        [
+                            6003.2,
+                            307.2
+                        ],
+                        [
+                            6028.8,
+                            307.2
+                        ],
+                        [
+                            6028.8,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59389094604492,
+                "center_latitude": 35.05534433191801,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.852829+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59113391682041,
+                35.05383254068783,
+                -106.59107354084371,
+                35.0538824819929
+            ],
+            "id": "21a13056944ba9304e40eb70f7dcaeb9",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591108,
+                            35.053833,
+                            0
+                        ],
+                        [
+                            -106.591074,
+                            35.053844,
+                            0
+                        ],
+                        [
+                            -106.591099,
+                            35.053882,
+                            0
+                        ],
+                        [
+                            -106.591134,
+                            35.053871,
+                            0
+                        ],
+                        [
+                            -106.591108,
+                            35.053833,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            3617.2
+                        ],
+                        [
+                            684.8,
+                            3697.8
+                        ],
+                        [
+                            787.2,
+                            3697.8
+                        ],
+                        [
+                            787.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59110372883205,
+                "center_latitude": 35.05385751134036,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.569844+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59252355443647,
+                35.05591699711191,
+                -106.59246317845977,
+                35.05596693841697
+            ],
+            "id": "45c475469c75aa067e271422735625bc",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592498,
+                            35.055917,
+                            0
+                        ],
+                        [
+                            -106.592463,
+                            35.055929,
+                            0
+                        ],
+                        [
+                            -106.592489,
+                            35.055967,
+                            0
+                        ],
+                        [
+                            -106.592524,
+                            35.055955,
+                            0
+                        ],
+                        [
+                            -106.592498,
+                            35.055917,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            3617.2
+                        ],
+                        [
+                            6252.8,
+                            3697.8
+                        ],
+                        [
+                            6355.2,
+                            3697.8
+                        ],
+                        [
+                            6355.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59249336644811,
+                "center_latitude": 35.05594196776444,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.666430+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59194538382728,
+                35.05470411018609,
+                -106.5918755901903,
+                35.05475719071125
+            ],
+            "id": "4b6195857b89f13e79a3f54454b479f4",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59192,
+                            35.054704,
+                            0
+                        ],
+                        [
+                            -106.591876,
+                            35.054719,
+                            0
+                        ],
+                        [
+                            -106.591901,
+                            35.054757,
+                            0
+                        ],
+                        [
+                            -106.591945,
+                            35.054742,
+                            0
+                        ],
+                        [
+                            -106.59192,
+                            35.054704,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3180.8,
+                            3180.8
+                        ],
+                        [
+                            3180.8,
+                            3283.2
+                        ],
+                        [
+                            3283.2,
+                            3283.2
+                        ],
+                        [
+                            3283.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59191048700879,
+                "center_latitude": 35.05473065044867,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.605889+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5917371654812,
+                35.0536314578009,
+                -106.59166737184424,
+                35.05368453832606
+            ],
+            "id": "f1705ff1feaa54253b89a8b634c94dce",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591712,
+                            35.053631,
+                            0
+                        ],
+                        [
+                            -106.591667,
+                            35.053646,
+                            0
+                        ],
+                        [
+                            -106.591693,
+                            35.053685,
+                            0
+                        ],
+                        [
+                            -106.591737,
+                            35.05367,
+                            0
+                        ],
+                        [
+                            -106.591712,
+                            35.053631,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            2220.8
+                        ],
+                        [
+                            684.8,
+                            2323.2
+                        ],
+                        [
+                            787.2,
+                            2323.2
+                        ],
+                        [
+                            787.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59170226866271,
+                "center_latitude": 35.05365799806348,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.484786+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5918449933713,
+                35.05359551517086,
+                -106.59180837754666,
+                35.05363753642524
+            ],
+            "id": "bf27f103a3e771728f5a53118928429c",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591819,
+                            35.053596,
+                            0
+                        ],
+                        [
+                            -106.591808,
+                            35.053599,
+                            0
+                        ],
+                        [
+                            -106.591834,
+                            35.053638,
+                            0
+                        ],
+                        [
+                            -106.591845,
+                            35.053634,
+                            0
+                        ],
+                        [
+                            -106.591819,
+                            35.053596,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            684.8,
+                            1971.2
+                        ],
+                        [
+                            684.8,
+                            1996.8
+                        ],
+                        [
+                            787.2,
+                            1996.8
+                        ],
+                        [
+                            787.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59182668545898,
+                "center_latitude": 35.05361652579806,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.500855+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59328721468994,
+                35.05474001182826,
+                -106.59321742105296,
+                35.054793092353414
+            ],
+            "id": "50fd38b53e990fe406adbd10fb996283",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593262,
+                            35.05474,
+                            0
+                        ],
+                        [
+                            -106.593217,
+                            35.054755,
+                            0
+                        ],
+                        [
+                            -106.593243,
+                            35.054793,
+                            0
+                        ],
+                        [
+                            -106.593287,
+                            35.054778,
+                            0
+                        ],
+                        [
+                            -106.593262,
+                            35.05474,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            684.8
+                        ],
+                        [
+                            4236.8,
+                            787.2
+                        ],
+                        [
+                            4339.2,
+                            787.2
+                        ],
+                        [
+                            4339.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59325231787145,
+                "center_latitude": 35.05476655209083,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.297061+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5916370614745,
+                35.05458725766896,
+                -106.5915766854978,
+                35.05463719897403
+            ],
+            "id": "ff5bb74169e288a590cb499943e0afac",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591612,
+                            35.054587,
+                            0
+                        ],
+                        [
+                            -106.591577,
+                            35.054599,
+                            0
+                        ],
+                        [
+                            -106.591602,
+                            35.054637,
+                            0
+                        ],
+                        [
+                            -106.591637,
+                            35.054626,
+                            0
+                        ],
+                        [
+                            -106.591612,
+                            35.054587,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            3617.2
+                        ],
+                        [
+                            2700.8,
+                            3697.8
+                        ],
+                        [
+                            2803.2,
+                            3697.8
+                        ],
+                        [
+                            2803.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59160687348614,
+                "center_latitude": 35.054612228321496,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.041763+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5922725415006,
+                35.054814684263036,
+                -106.59220274786362,
+                35.05486776478819
+            ],
+            "id": "1328882efb99f795dcee15aaf1729060",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592247,
+                            35.054815,
+                            0
+                        ],
+                        [
+                            -106.592203,
+                            35.054829,
+                            0
+                        ],
+                        [
+                            -106.592228,
+                            35.054868,
+                            0
+                        ],
+                        [
+                            -106.592273,
+                            35.054853,
+                            0
+                        ],
+                        [
+                            -106.592247,
+                            35.054815,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            2700.8
+                        ],
+                        [
+                            3660.8,
+                            2803.2
+                        ],
+                        [
+                            3763.2,
+                            2803.2
+                        ],
+                        [
+                            3763.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59223764468211,
+                "center_latitude": 35.05484122452561,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.577645+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59290386638206,
+                35.05416498936644,
+                -106.59283407274508,
+                35.054218069891604
+            ],
+            "id": "680bb48afddcbe51128526b7cb9c3a46",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592878,
+                            35.054165,
+                            0
+                        ],
+                        [
+                            -106.592834,
+                            35.05418,
+                            0
+                        ],
+                        [
+                            -106.59286,
+                            35.054218,
+                            0
+                        ],
+                        [
+                            -106.592904,
+                            35.054203,
+                            0
+                        ],
+                        [
+                            -106.592878,
+                            35.054165,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            684.8
+                        ],
+                        [
+                            2700.8,
+                            787.2
+                        ],
+                        [
+                            2803.2,
+                            787.2
+                        ],
+                        [
+                            2803.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59286896956357,
+                "center_latitude": 35.05419152962902,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.626179+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5915620355194,
+                35.05412908772427,
+                -106.59149224188242,
+                35.05418216824943
+            ],
+            "id": "e85d55d07f8891e871f586c366b41ec8",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591536,
+                            35.054129,
+                            0
+                        ],
+                        [
+                            -106.591492,
+                            35.054144,
+                            0
+                        ],
+                        [
+                            -106.591518,
+                            35.054182,
+                            0
+                        ],
+                        [
+                            -106.591562,
+                            35.054167,
+                            0
+                        ],
+                        [
+                            -106.591536,
+                            35.054129,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            3180.8
+                        ],
+                        [
+                            1644.8,
+                            3283.2
+                        ],
+                        [
+                            1747.2,
+                            3283.2
+                        ],
+                        [
+                            1747.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59152713870091,
+                "center_latitude": 35.05415562798685,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:19.734747+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59210579541995,
+                35.05372820778937,
+                -106.59203600178297,
+                35.05378128831453
+            ],
+            "id": "cf1cfe12d0e30c4ff7270fce5fd30fac",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59208,
+                            35.053728,
+                            0
+                        ],
+                        [
+                            -106.592036,
+                            35.053743,
+                            0
+                        ],
+                        [
+                            -106.592062,
+                            35.053781,
+                            0
+                        ],
+                        [
+                            -106.592106,
+                            35.053767,
+                            0
+                        ],
+                        [
+                            -106.59208,
+                            35.053728,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            1644.8
+                        ],
+                        [
+                            1164.8,
+                            1747.2
+                        ],
+                        [
+                            1267.2,
+                            1747.2
+                        ],
+                        [
+                            1267.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59207089860146,
+                "center_latitude": 35.05375474805195,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.165414+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5926403144204,
+                35.05376966142394,
+                -106.59257052078341,
+                35.053822741949105
+            ],
+            "id": "fa7265cba5c34d22626c743d6ba300bc",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592615,
+                            35.05377,
+                            0
+                        ],
+                        [
+                            -106.592571,
+                            35.053784,
+                            0
+                        ],
+                        [
+                            -106.592596,
+                            35.053823,
+                            0
+                        ],
+                        [
+                            -106.59264,
+                            35.053808,
+                            0
+                        ],
+                        [
+                            -106.592615,
+                            35.05377,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1644.8,
+                            684.8
+                        ],
+                        [
+                            1644.8,
+                            787.2
+                        ],
+                        [
+                            1747.2,
+                            787.2
+                        ],
+                        [
+                            1747.2,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5926054176019,
+                "center_latitude": 35.053796201686524,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.736973+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5926558898085,
+                35.055389706724846,
+                -106.5925860961715,
+                35.05544278725001
+            ],
+            "id": "01c86284a1bcd1b20f90e81d4871ee99",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.59263,
+                            35.05539,
+                            0
+                        ],
+                        [
+                            -106.592586,
+                            35.055404,
+                            0
+                        ],
+                        [
+                            -106.592612,
+                            35.055443,
+                            0
+                        ],
+                        [
+                            -106.592656,
+                            35.055428,
+                            0
+                        ],
+                        [
+                            -106.59263,
+                            35.05539,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5196.8,
+                            2700.8
+                        ],
+                        [
+                            5196.8,
+                            2803.2
+                        ],
+                        [
+                            5299.2,
+                            2803.2
+                        ],
+                        [
+                            5299.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59262099298999,
+                "center_latitude": 35.05541624698743,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.188186+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59212747427351,
+                35.055005996978544,
+                -106.59207684805193,
+                35.05503032638062
+            ],
+            "id": "c98beeb019529d374f2d964f8558f5f0",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592121,
+                            35.055006,
+                            0
+                        ],
+                        [
+                            -106.592077,
+                            35.055021,
+                            0
+                        ],
+                        [
+                            -106.592083,
+                            35.05503,
+                            0
+                        ],
+                        [
+                            -106.592127,
+                            35.055016,
+                            0
+                        ],
+                        [
+                            -106.592121,
+                            35.055006,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            3180.8
+                        ],
+                        [
+                            3987.2,
+                            3283.2
+                        ],
+                        [
+                            4012.8,
+                            3283.2
+                        ],
+                        [
+                            4012.8,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59210216116273,
+                "center_latitude": 35.05501816167958,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.713026+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59343924240146,
+                35.05534821582858,
+                -106.59336944876448,
+                35.055401296353736
+            ],
+            "id": "3d61de0fdca16d8a8f414d0137a4b706",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593414,
+                            35.055348,
+                            0
+                        ],
+                        [
+                            -106.593369,
+                            35.055363,
+                            0
+                        ],
+                        [
+                            -106.593395,
+                            35.055401,
+                            0
+                        ],
+                        [
+                            -106.593439,
+                            35.055387,
+                            0
+                        ],
+                        [
+                            -106.593414,
+                            35.055348,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            1164.8
+                        ],
+                        [
+                            5676.8,
+                            1267.2
+                        ],
+                        [
+                            5779.2,
+                            1267.2
+                        ],
+                        [
+                            5779.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59340434558298,
+                "center_latitude": 35.055374756091155,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.130296+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59202040978238,
+                35.05516228013077,
+                -106.59196003380568,
+                35.055212221435845
+            ],
+            "id": "142ee9f96a6d1ebb1a3915a71087ad1b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591995,
+                            35.055162,
+                            0
+                        ],
+                        [
+                            -106.59196,
+                            35.055174,
+                            0
+                        ],
+                        [
+                            -106.591986,
+                            35.055212,
+                            0
+                        ],
+                        [
+                            -106.59202,
+                            35.055201,
+                            0
+                        ],
+                        [
+                            -106.591995,
+                            35.055162,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            3617.2
+                        ],
+                        [
+                            4236.8,
+                            3697.8
+                        ],
+                        [
+                            4339.2,
+                            3697.8
+                        ],
+                        [
+                            4339.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59199022179402,
+                "center_latitude": 35.055187250783305,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.425642+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59233483560062,
+                35.05493687653617,
+                -106.59228420937905,
+                35.05496120593824
+            ],
+            "id": "29c6ae903d6d0a661dd9b86757dacdfe",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592328,
+                            35.054937,
+                            0
+                        ],
+                        [
+                            -106.592284,
+                            35.054952,
+                            0
+                        ],
+                        [
+                            -106.592291,
+                            35.054961,
+                            0
+                        ],
+                        [
+                            -106.592335,
+                            35.054946,
+                            0
+                        ],
+                        [
+                            -106.592328,
+                            35.054937,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            2700.8
+                        ],
+                        [
+                            3987.2,
+                            2803.2
+                        ],
+                        [
+                            4012.8,
+                            2803.2
+                        ],
+                        [
+                            4012.8,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59230952248984,
+                "center_latitude": 35.0549490412372,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.613213+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59370889782859,
+                35.05540128765934,
+                -106.59365827160701,
+                35.05542561706141
+            ],
+            "id": "35515bdab83efa23ea7fe641bfc66ed3",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593703,
+                            35.055401,
+                            0
+                        ],
+                        [
+                            -106.593658,
+                            35.055416,
+                            0
+                        ],
+                        [
+                            -106.593665,
+                            35.055426,
+                            0
+                        ],
+                        [
+                            -106.593709,
+                            35.055411,
+                            0
+                        ],
+                        [
+                            -106.593703,
+                            35.055401,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6003.2,
+                            684.8
+                        ],
+                        [
+                            6003.2,
+                            787.2
+                        ],
+                        [
+                            6028.8,
+                            787.2
+                        ],
+                        [
+                            6028.8,
+                            684.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59368358471781,
+                "center_latitude": 35.055413452360376,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.519484+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59307985336282,
+                35.05480913227063,
+                -106.59301005972584,
+                35.05486221279579
+            ],
+            "id": "dff58c89227ff7ce0cfe5d68abf025b4",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593054,
+                            35.054809,
+                            0
+                        ],
+                        [
+                            -106.59301,
+                            35.054824,
+                            0
+                        ],
+                        [
+                            -106.593036,
+                            35.054862,
+                            0
+                        ],
+                        [
+                            -106.59308,
+                            35.054847,
+                            0
+                        ],
+                        [
+                            -106.593054,
+                            35.054809,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            1164.8
+                        ],
+                        [
+                            4236.8,
+                            1267.2
+                        ],
+                        [
+                            4339.2,
+                            1267.2
+                        ],
+                        [
+                            4339.2,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59304495654433,
+                "center_latitude": 35.05483567253321,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:16.962713+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59291944177015,
+                35.055785034667345,
+                -106.59284964813317,
+                35.05583811519251
+            ],
+            "id": "2a36ae96f0e9ca2c5ead5776b7fbed0a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592894,
+                            35.055785,
+                            0
+                        ],
+                        [
+                            -106.59285,
+                            35.0558,
+                            0
+                        ],
+                        [
+                            -106.592875,
+                            35.055838,
+                            0
+                        ],
+                        [
+                            -106.592919,
+                            35.055823,
+                            0
+                        ],
+                        [
+                            -106.592894,
+                            35.055785,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6252.8,
+                            2700.8
+                        ],
+                        [
+                            6252.8,
+                            2803.2
+                        ],
+                        [
+                            6355.2,
+                            2803.2
+                        ],
+                        [
+                            6355.2,
+                            2700.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59288454495166,
+                "center_latitude": 35.055811574929926,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.579687+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59144223917319,
+                35.05394939320496,
+                -106.59137244553621,
+                35.054002473730115
+            ],
+            "id": "b9565e0006a012202ad5dda096b8ee8b",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591417,
+                            35.053949,
+                            0
+                        ],
+                        [
+                            -106.591372,
+                            35.053964,
+                            0
+                        ],
+                        [
+                            -106.591398,
+                            35.054002,
+                            0
+                        ],
+                        [
+                            -106.591442,
+                            35.053988,
+                            0
+                        ],
+                        [
+                            -106.591417,
+                            35.053949,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            1164.8,
+                            3180.8
+                        ],
+                        [
+                            1164.8,
+                            3283.2
+                        ],
+                        [
+                            1267.2,
+                            3283.2
+                        ],
+                        [
+                            1267.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5914073423547,
+                "center_latitude": 35.053975933467534,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:19.683081+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59237979882101,
+                35.055701363688726,
+                -106.59231942284433,
+                35.05575130499379
+            ],
+            "id": "22e1a1aecc816fb69612ca653c805e7f",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592354,
+                            35.055701,
+                            0
+                        ],
+                        [
+                            -106.592319,
+                            35.055713,
+                            0
+                        ],
+                        [
+                            -106.592345,
+                            35.055751,
+                            0
+                        ],
+                        [
+                            -106.59238,
+                            35.05574,
+                            0
+                        ],
+                        [
+                            -106.592354,
+                            35.055701,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            5676.8,
+                            3617.2
+                        ],
+                        [
+                            5676.8,
+                            3697.8
+                        ],
+                        [
+                            5779.2,
+                            3697.8
+                        ],
+                        [
+                            5779.2,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59234961083266,
+                "center_latitude": 35.05572633434126,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.574744+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59287249203571,
+                35.054878252712996,
+                -106.59280269839873,
+                35.05493133323816
+            ],
+            "id": "08c67473cd79d5dc8ea25a01fd6c1253",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592847,
+                            35.054878,
+                            0
+                        ],
+                        [
+                            -106.592803,
+                            35.054893,
+                            0
+                        ],
+                        [
+                            -106.592828,
+                            35.054931,
+                            0
+                        ],
+                        [
+                            -106.592872,
+                            35.054917,
+                            0
+                        ],
+                        [
+                            -106.592847,
+                            35.054878,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4236.8,
+                            1644.8
+                        ],
+                        [
+                            4236.8,
+                            1747.2
+                        ],
+                        [
+                            4339.2,
+                            1747.2
+                        ],
+                        [
+                            4339.2,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59283759521722,
+                "center_latitude": 35.05490479297558,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.631875+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59182558748107,
+                35.05452441566677,
+                -106.59175579384409,
+                35.05457749619193
+            ],
+            "id": "1e9cc320a91cd5d9292f9703ac32d212",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.5918,
+                            35.054524,
+                            0
+                        ],
+                        [
+                            -106.591756,
+                            35.054539,
+                            0
+                        ],
+                        [
+                            -106.591781,
+                            35.054577,
+                            0
+                        ],
+                        [
+                            -106.591826,
+                            35.054563,
+                            0
+                        ],
+                        [
+                            -106.5918,
+                            35.054524,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            2700.8,
+                            3180.8
+                        ],
+                        [
+                            2700.8,
+                            3283.2
+                        ],
+                        [
+                            2803.2,
+                            3283.2
+                        ],
+                        [
+                            2803.2,
+                            3180.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59179069066258,
+                "center_latitude": 35.05455095592935,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.548706+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59361437236325,
+                35.0548505859052,
+                -106.59354457872628,
+                35.05490366643036
+            ],
+            "id": "048c3dc8a2e1f0dcf1c71a08636da88a",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593589,
+                            35.054851,
+                            0
+                        ],
+                        [
+                            -106.593545,
+                            35.054865,
+                            0
+                        ],
+                        [
+                            -106.59357,
+                            35.054904,
+                            0
+                        ],
+                        [
+                            -106.593614,
+                            35.054889,
+                            0
+                        ],
+                        [
+                            -106.593589,
+                            35.054851,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            4716.8,
+                            204.8
+                        ],
+                        [
+                            4716.8,
+                            307.2
+                        ],
+                        [
+                            4819.2,
+                            307.2
+                        ],
+                        [
+                            4819.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59357947554477,
+                "center_latitude": 35.05487712616778,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.727932+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59344137493478,
+                35.05575860611222,
+                -106.59338960066488,
+                35.05578465758676
+            ],
+            "id": "47bec03f45d95cb7b851ec5f862aeb09",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593434,
+                            35.055759,
+                            0
+                        ],
+                        [
+                            -106.59339,
+                            35.055773,
+                            0
+                        ],
+                        [
+                            -106.593397,
+                            35.055785,
+                            0
+                        ],
+                        [
+                            -106.593441,
+                            35.05577,
+                            0
+                        ],
+                        [
+                            -106.593434,
+                            35.055759,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            1644.8
+                        ],
+                        [
+                            6588.4,
+                            1747.2
+                        ],
+                        [
+                            6618.6,
+                            1747.2
+                        ],
+                        [
+                            6618.6,
+                            1644.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59341548779983,
+                "center_latitude": 35.05577163184949,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.547844+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59247990282773,
+                35.05474556382066,
+                -106.59241010919074,
+                35.05479864434582
+            ],
+            "id": "a3a5100fa445f109aa8daeca6a2e7b57",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592454,
+                            35.054746,
+                            0
+                        ],
+                        [
+                            -106.59241,
+                            35.05476,
+                            0
+                        ],
+                        [
+                            -106.592436,
+                            35.054799,
+                            0
+                        ],
+                        [
+                            -106.59248,
+                            35.054784,
+                            0
+                        ],
+                        [
+                            -106.592454,
+                            35.054746,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            2220.8
+                        ],
+                        [
+                            3660.8,
+                            2323.2
+                        ],
+                        [
+                            3763.2,
+                            2323.2
+                        ],
+                        [
+                            3763.2,
+                            2220.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59244500600923,
+                "center_latitude": 35.05477210408324,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:15.910725+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59258773071781,
+                35.05470962119063,
+                -106.59255111489317,
+                35.05475164244501
+            ],
+            "id": "b9dfd4f839a24a6d754c2460ad656edb",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.592562,
+                            35.05471,
+                            0
+                        ],
+                        [
+                            -106.592551,
+                            35.054713,
+                            0
+                        ],
+                        [
+                            -106.592577,
+                            35.054752,
+                            0
+                        ],
+                        [
+                            -106.592588,
+                            35.054748,
+                            0
+                        ],
+                        [
+                            -106.592562,
+                            35.05471,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3660.8,
+                            1971.2
+                        ],
+                        [
+                            3660.8,
+                            1996.8
+                        ],
+                        [
+                            3763.2,
+                            1996.8
+                        ],
+                        [
+                            3763.2,
+                            1971.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.5925694228055,
+                "center_latitude": 35.05473063181782,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:20.535316+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.59193894826696,
+                35.05506883898073,
+                -106.59189773970564,
+                35.055090029162706
+            ],
+            "id": "f99632918969fda4339ef1391a8dbf52",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.591933,
+                            35.055069,
+                            0
+                        ],
+                        [
+                            -106.591898,
+                            35.05508,
+                            0
+                        ],
+                        [
+                            -106.591904,
+                            35.05509,
+                            0
+                        ],
+                        [
+                            -106.591939,
+                            35.055078,
+                            0
+                        ],
+                        [
+                            -106.591933,
+                            35.055069,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            3987.2,
+                            3617.2
+                        ],
+                        [
+                            3987.2,
+                            3697.8
+                        ],
+                        [
+                            4012.8,
+                            3697.8
+                        ],
+                        [
+                            4012.8,
+                            3617.2
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59191834398631,
+                "center_latitude": 35.05507943407172,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:18.163900+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [
+                -106.5936487362619,
+                35.055689485669845,
+                -106.59359696199199,
+                35.055715537144394
+            ],
+            "id": "11e08bee96ff0ac4af63bc24ca57de9e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.593641,
+                            35.055689,
+                            0
+                        ],
+                        [
+                            -106.593597,
+                            35.055704,
+                            0
+                        ],
+                        [
+                            -106.593604,
+                            35.055716,
+                            0
+                        ],
+                        [
+                            -106.593649,
+                            35.055701,
+                            0
+                        ],
+                        [
+                            -106.593641,
+                            35.055689,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            6588.4,
+                            1164.8
+                        ],
+                        [
+                            6588.4,
+                            1267.2
+                        ],
+                        [
+                            6618.6,
+                            1267.2
+                        ],
+                        [
+                            6618.6,
+                            1164.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": -106.59362284912696,
+                "center_latitude": 35.05570251140712,
+                "inferenceMetadata": {
+                    "jobId": "ae32b3dba079ff7af1c38d478398a619",
+                    "filePath": "s3://test-images-825536440648/sicd_example_1_PFA_RE32F_IM32F_HH.nitf",
+                    "receiveTime": "2023-09-07T23:50:14.614460",
+                    "inferenceTime": "2023-09-07T23:50:17.773677+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "SICD: 20160921f01p0009faradx0613_284_21114HH",
+                                "sourceDt": "2021-11-30T20:59:38",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/data/centerpoint.sicd-umbra-chip.ntf.geojson
+++ b/src/data/centerpoint.sicd-umbra-chip.ntf.geojson
@@ -1,0 +1,99 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "bbox": [
+                100.74940201674278,
+                13.690332898456186,
+                100.75018131659057,
+                13.690778212654925
+            ],
+            "id": "dad74d77fc55513a1b409335fa82299e",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            100.749931,
+                            13.690778,
+                            0
+                        ],
+                        [
+                            100.749402,
+                            13.690723,
+                            0
+                        ],
+                        [
+                            100.749653,
+                            13.690333,
+                            0
+                        ],
+                        [
+                            100.750181,
+                            13.690389,
+                            0
+                        ],
+                        [
+                            100.749931,
+                            13.690778,
+                            0
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "detection": {
+                    "type": "Polygon",
+                    "pixelCoordinates": [
+                        [
+                            204.8,
+                            204.8
+                        ],
+                        [
+                            204.8,
+                            307.2
+                        ],
+                        [
+                            307.2,
+                            307.2
+                        ],
+                        [
+                            307.2,
+                            204.8
+                        ]
+                    ],
+                    "ontology": [
+                        {
+                            "iri": "sample_object",
+                            "detectionScore": 1
+                        }
+                    ],
+                    "coordinates": []
+                },
+                "center_longitude": 100.74979166666668,
+                "center_latitude": 13.690555555555555,
+                "inferenceMetadata": {
+                    "jobId": "b7aa3a0a2d007cd600a1e274ddd023f5",
+                    "filePath": "s3://test-images-825536440648/umbra-sicd121-chip1.ntf",
+                    "receiveTime": "2023-09-07T23:39:41.316052",
+                    "inferenceTime": "2023-09-07T23:39:42.074760+00:00",
+                    "tileOverlapFeatureSelection": "{\"algorithm\": \"NMS\", \"iou_threshold\": 0.75, \"skip_box_threshold\": 0.0001, \"sigma\": 0.1}"
+                },
+                "source": [
+                    {
+                        "fileType": "NITF",
+                        "info": {
+                            "imageCategory": "SAR",
+                            "metadata": {
+                                "sourceId": "",
+                                "sourceDt": "2002-12-16T15:16:29",
+                                "classification": "UNCLASSIFIED"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
**Description of changes:**
- Update the automated integration testing suite to include SICD imagery examples. I have added 3 SICD samples
  - `sicd-inteferometric-hh.nitf` was taken from https://github.com/ngageoint/six-library/wiki/Sample-SICDs
  - `sicd-capella-chip` and `sicd-umbra-chip` are the two small tiles taken from the large imagery file. The imagery file that was chipped out of was: https://github.com/aws-solutions-library-samples/osml-imagery-toolkit/pull/10
 
**Test**
- Ran the following command to run the integration test against my dev account

```
./bin/run_test.sh ${IMAGE_TYPE} ${MODEL_TYPE} NITF NONE us-west-2 $ACCOUNT_NUMBER
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
