### PR TITLE
fix: updating integ tests to use postProcessing parameter in image request

### DIFF
--- a/src/aws/osml/utils/integ_utils.py
+++ b/src/aws/osml/utils/integ_utils.py
@@ -440,7 +440,7 @@ def build_image_processing_request(endpoint: str, endpoint_type: str, image_url:
         "imageProcessorTileOverlap": OSMLConfig.TILE_OVERLAP,
         "imageProcessorTileFormat": OSMLConfig.TILE_FORMAT,
         "imageProcessorTileCompression": OSMLConfig.TILE_COMPRESSION,
-        "featureSelectionOptions": OSMLConfig.FEATURE_SELECTION_OPTIONS,
+        "postProcessing": json.loads(OSMLConfig.POST_PROCESSING),
         "regionOfInterest": OSMLConfig.REGION_OF_INTEREST,
     }
 

--- a/src/aws/osml/utils/osml_config.py
+++ b/src/aws/osml/utils/osml_config.py
@@ -51,9 +51,9 @@ class OSMLConfig:
     TILE_COMPRESSION: str = os.environ.get("TILE_COMPRESSION", "NONE")
     TILE_SIZE: int = int(os.environ.get("TILE_SIZE", "512"))
     TILE_OVERLAP: int = int(os.environ.get("TILE_OVERLAP", "128"))
-    FEATURE_SELECTION_OPTIONS: str = os.environ.get(
-        "FEATURE_SELECTION_OPTIONS",
-        '{"algorithm": "NMS", "iou_threshold":  0.75, "skip_box_threshold": 0.0001, "sigma": .1}',
+    POST_PROCESSING: str = os.environ.get(
+        "POST_PROCESSING",
+        '[{"step": "FEATURE_DISTILLATION", "algorithm": {"algorithmType": "NMS", "iouThreshold":  0.75}}]',
     )
     REGION_OF_INTEREST: str = os.environ.get("REGION_OF_INTEREST")
 


### PR DESCRIPTION
`featureSelectionOptions` was deprecated in MR so this is to update the tests to use the newer `postProcessing` construct.  This change has no functional impact to the tests since the old `featureSelectionOptions` parameter was ignored by MR and MR would use the default `postProcessing` value anyway, which is the same value set in the new parameter in this PR.

**Issue #, if available:** n/a

### Notes


### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
