### PR TITLE
fix: deprecate job_arn request parameter

### DIFF
--- a/src/aws/osml/utils/integ_utils.py
+++ b/src/aws/osml/utils/integ_utils.py
@@ -427,7 +427,6 @@ def build_image_processing_request(endpoint: str, endpoint_type: str, image_url:
     logging.info(f"Creating request job_id={job_id}")
 
     image_processing_request: Dict[str, Any] = {
-        "jobArn": f"arn:aws:oversightml:{OSMLConfig.REGION}:{OSMLConfig.ACCOUNT}:ipj/{job_name}",
         "jobName": job_name,
         "jobId": job_id,
         "imageUrls": [image_url],


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- The "job_arn" parameter is redundant with "job_id" and therefore not needed. This will not break any changes.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
