### PR TITLE
fix: rename sync to sink

### DIFF
--- a/src/aws/osml/integ/http_centerpoint/test_http_centerpoint_model.py
+++ b/src/aws/osml/integ/http_centerpoint/test_http_centerpoint_model.py
@@ -42,7 +42,7 @@ def test_model_runner_centerpoint_http_model() -> None:
     # count the created features in the table for this image
     count_features(image_id=image_id, ddb_client=ddb_client())
 
-    # verify the results we created in the appropriate syncs
+    # verify the results we created in the appropriate sinks
     validate_features_match(
         image_processing_request=image_processing_request,
         job_id=job_id,

--- a/src/aws/osml/integ/sm_aircraft/test_sm_aircraft_model.py
+++ b/src/aws/osml/integ/sm_aircraft/test_sm_aircraft_model.py
@@ -20,7 +20,7 @@ def test_model_runner_aircraft_model() -> None:
         sqs_client(), OSMLConfig.SM_AIRCRAFT_MODEL, "SM_ENDPOINT", kinesis_client()
     )
 
-    # Verify the results we created in the appropriate syncs
+    # Verify the results we created in the appropriate sinks
     validate_features_match(
         image_processing_request=image_processing_request,
         job_id=job_id,

--- a/src/aws/osml/integ/sm_centerpoint/test_sm_centerpoint_model.py
+++ b/src/aws/osml/integ/sm_centerpoint/test_sm_centerpoint_model.py
@@ -35,7 +35,7 @@ def test_model_runner_center_point_model() -> None:
     # count the features created in the table for this image
     count_features(image_id=image_id, ddb_client=ddb_client())
 
-    # verify the results we created in the appropriate syncs
+    # verify the results we created in the appropriate sinks
     validate_features_match(
         image_processing_request=image_processing_request,
         job_id=job_id,

--- a/src/aws/osml/utils/integ_utils.py
+++ b/src/aws/osml/utils/integ_utils.py
@@ -209,17 +209,17 @@ def validate_features_match(
                     found_outputs = found_outputs + 1
             if found_outputs == len(outputs):
                 done = True
-                logging.info(f"{found_outputs} output syncs validated, tests succeeded!")
+                logging.info(f"{found_outputs} output sinks validated, tests succeeded!")
             else:
                 max_retries -= 1
                 time.sleep(retry_interval)
-                logging.info(f"Not all output syncs were validated, retrying. Retries remaining: {max_retries}")
+                logging.info(f"Not all output sinks were validated, retrying. Retries remaining: {max_retries}")
     assert done
 
 
 def validate_s3_features_match(bucket: str, prefix: str, expected_features: List[Feature], s3_client: boto3.client) -> bool:
     """
-    Checks a s3 output sync against known good feature results for a given test image.
+    Checks a s3 output sink against known good feature results for a given test image.
 
     :param bucket: Folder inside s3
     :param prefix: String of characters at the beginning of the object key name
@@ -256,7 +256,7 @@ def validate_kinesis_features_match(
     kinesis_client: boto3.client,
 ) -> bool:
     """
-    Checks a Kinesis output sync against know good feature results for a given test image
+    Checks a Kinesis output sink against know good feature results for a given test image
 
     :param job_id: Job-id associated with the request
     :param stream: Kinesis stream name


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
In this context, a sink is the destination of a data flow (S3, Kinesis, etc.) so sync is incorrect and may cause confusion.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
