### PR TITLE
fix: update test path to reflect osml-cdk-constructs 2.x

### DIFF
--- a/bin/process_image.py
+++ b/bin/process_image.py
@@ -56,7 +56,7 @@ def main():
     args = parser.parse_args()
 
     # standard test images deployed by CDK
-    image_bucket: str = f"mr-test-images-{args.account}"
+    image_bucket: str = f"osml-test-images-{args.account}"
     deployed_images: dict = {
         "small": f"s3://{image_bucket}/small.tif",
         "large": f"s3://{image_bucket}/large.tif",

--- a/src/aws/osml/utils/osml_config.py
+++ b/src/aws/osml/utils/osml_config.py
@@ -33,12 +33,12 @@ class OSMLConfig:
 
     # bucket name prefixes
     S3_RESULTS_BUCKET: str = os.getenv("S3_RESULTS_BUCKET")
-    S3_RESULTS_BUCKET_PREFIX: str = os.getenv("S3_RESULTS_BUCKET_PREFIX", "mr-test-results")
-    S3_IMAGE_BUCKET_PREFIX: str = os.getenv("S3_IMAGE_BUCKET_PREFIX", "mr-test-images")
+    S3_RESULTS_BUCKET_PREFIX: str = os.getenv("S3_RESULTS_BUCKET_PREFIX", "mr-bucket-sink")
+    S3_IMAGE_BUCKET_PREFIX: str = os.getenv("S3_IMAGE_BUCKET_PREFIX", "osml-test-images")
 
     # stream name prefixes
     KINESIS_RESULTS_STREAM: str = os.getenv("KINESIS_RESULTS_STREAM")
-    KINESIS_RESULTS_STREAM_PREFIX: str = os.getenv("KINESIS_RESULTS_STREAM_PREFIX", "mr-test-stream")
+    KINESIS_RESULTS_STREAM_PREFIX: str = os.getenv("KINESIS_RESULTS_STREAM_PREFIX", "mr-stream-sink")
 
     # deployment info
     ACCOUNT: str = os.environ.get("ACCOUNT")


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Update test path for test images, kinesis(es), and s3 result to reflect on the `osml-cdk-constructs 2.x`. Do not merge until the guidance repo is utilizing `osml-cdk-constructs 2.x`

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
