### PR TITLE
fix: validate kinesis extends to appends

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: osml_models
+name: osml_model_runner_test
 channels:
   - conda-forge
 dependencies:

--- a/src/aws/osml/utils/integ_utils.py
+++ b/src/aws/osml/utils/integ_utils.py
@@ -272,7 +272,7 @@ def validate_kinesis_features_match(
     for record in records:
         # Look for records that pertain to the target image_id
         if record["PartitionKey"] == job_id:
-            kinesis_features.extend(geojson.loads(record["Data"])["features"])
+            kinesis_features.append(geojson.loads(record["Data"])["features"])
         else:
             logging.warning(f"Found partition key: {record['PartitionKey']}")
             logging.warning(f"Looking for partition key: {job_id}")
@@ -402,9 +402,9 @@ def build_image_processing_request(endpoint: str, endpoint_type: str, image_url:
     In the future this could, and probably should, be extended to build more variant image requests for additional
     testing configurations.
 
+    :param endpoint: Model endpoint that you want to build the image_request for
     :param endpoint_type: The type of endpoint you want to build the image_request for SM/HTTP
     :param image_url: URL to the image you want to process
-    :param endpoint: Model endpoint that you want to build the image_request for
 
     :return: Dictionary representation of the image request
     """


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
-  Change `extends` to `appends` since we have shifted the kinesis data stream from put_record to put_records.

It depends on this PR to be merged in: https://github.com/aws-solutions-library-samples/osml-model-runner/pull/92

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
