### PR TITLE
fix: check if processing_duration is None

### DIFF
--- a/src/aws/osml/utils/integ_utils.py
+++ b/src/aws/osml/utils/integ_utils.py
@@ -117,7 +117,10 @@ def monitor_job_status(sqs_client: boto3.resource, image_id: str) -> None:
                     logging.info("\tIN_PROGRESS message found! Waiting for SUCCESS message...")
                 elif message_image_status == "SUCCESS" and message_image_id == image_id:
                     processing_duration = message_attributes.get("processing_duration", {}).get("Value")
-                    assert float(processing_duration) > 0
+                    if processing_duration is not None:
+                        assert float(processing_duration) > 0
+                    else:
+                        logging.warning("Processing duration is None for SUCCESS message")
                     done = True
                     logging.info(f"\tSUCCESS message found!  Image took {processing_duration} seconds to process")
                 elif (


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- The integration tests consistently fail in PDT/OSU regions, where they gracefully handle the failure due to the processing_duration value being returned as empty.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
