### PR TITLE
feature: failure model integ tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ To execute the integration test, exclude `--skip_integ` from the command line in
 | tile_jpeg                   | aircraft    |
 | tile_png                    | aircraft    |
 
+### Failure Model Testing
+
+The failure model provides controlled error simulation for testing error resilience and partial job completion handling. It triggers different failure behaviors based on the dominant color of image tiles:
+
+| Color  | Behavior | HTTP Status | Description |
+|--------|----------|-------------|-------------|
+| Red    | Server Error | 500 | Returns "Unable to process request" |
+| Blue   | Timeout | 408 | Simulates processing timeout (5s delay) |
+| Green  | Malformed JSON | 200 | Returns invalid JSON response |
+| Purple | Schema Violation | 200 | Returns JSON with invalid GeoJSON schema |
+| Other  | Normal Processing | 200 | Returns standard detection results |
+
+**Example:**
+
+```bash
+python3 bin/process_image.py --image failure_model_checker_tile --model failure --tile_overlap 0
+```
+This test validates:
+- Handling partial job completion (PARTIAL/FAIL status)
+- Proper error logging and retry mechanisms
+- Tile-level success/failure tracking in DynamoDB
+
+
 ### Running LoadTest
 
 You can run the load test against your dev account and be able to determine the cost and the performance. **Please advise** it can potentially rack up your AWS bills!

--- a/bin/process_image.py
+++ b/bin/process_image.py
@@ -69,6 +69,7 @@ def main():
         "sicd_umbra_chip_ntf": f"s3://{image_bucket}/sicd-umbra-chip.ntf",
         "sicd_interferometric_hh_ntf": f"s3://{image_bucket}/sicd-interferometric-hh.nitf",
         "wbid": f"s3://{image_bucket}/wbid.ntf",
+        "failure_model_checker_tile": f"s3://{image_bucket}/failure_model_checker_tile.tif",
     }
 
     # call into the root directory of this package so that we can run this script from anywhere.

--- a/src/aws/osml/integ/sm_failure/__init__.py
+++ b/src/aws/osml/integ/sm_failure/__init__.py
@@ -1,0 +1,1 @@
+#  Copyright 2023 Amazon.com, Inc. or its affiliates.

--- a/src/aws/osml/integ/sm_failure/test_sm_failure_model.py
+++ b/src/aws/osml/integ/sm_failure/test_sm_failure_model.py
@@ -1,0 +1,63 @@
+#  Copyright 2023 Amazon.com, Inc. or its affiliates.
+
+import logging
+
+from aws.osml.utils import (
+    OSMLConfig,
+    analyze_failure_model_results,
+    count_features,
+    count_region_request_items,
+    ddb_client,
+    kinesis_client,
+    run_failure_model_on_image,
+    s3_client,
+    sqs_client,
+    validate_expected_region_request_items,
+    validate_features_match,
+)
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def test_model_runner_failure_model() -> None:
+    """
+    Run the test using the Failure Model and validate the number of successful tiles and handling of various failure types
+
+    :return: None
+    """
+
+    # launch our image request and validate it completes
+    image_id, job_id, image_processing_request, shard_iter = run_failure_model_on_image(
+        sqs_client(), OSMLConfig.SM_FAILURE_MODEL, "SM_ENDPOINT", kinesis_client()
+    )
+    failure_results = analyze_failure_model_results(image_id=image_id, ddb_client=ddb_client())
+
+    # Validate based on results
+    if failure_results["failed_tiles"] == 0:
+        # No failures - normal validation
+        count_features(image_id=image_id, ddb_client=ddb_client())
+
+        # verify the results we created in the appropriate sinks
+        validate_features_match(
+            image_processing_request=image_processing_request,
+            job_id=job_id,
+            shard_iter=shard_iter,
+            s3_client=s3_client(),
+            kinesis_client=kinesis_client(),
+        )
+
+        # validate the number of region requests that were created in the process and check if they are succeeded
+        region_request_count = count_region_request_items(image_id=image_id, ddb_client=ddb_client())
+        validate_expected_region_request_items(region_request_count)
+    else:
+        # Has failures - validate counts
+        if "failure_model_checker" in image_id:
+            assert failure_results["total_tiles"] == 16
+            assert (
+                failure_results["failed_tiles"] == 4 and failure_results["failed_tiles"] < failure_results["total_tiles"]
+            )  # failed tiles should not be all of them
+            assert failure_results["successful_tiles"] == 12
+            assert failure_results["region_status"] == "PARTIAL"  # result should be a PARTIAL type
+            logging.info("Checkerboard failures passed!")
+        logging.info(f"Results: {failure_results}")

--- a/src/aws/osml/utils/__init__.py
+++ b/src/aws/osml/utils/__init__.py
@@ -6,10 +6,12 @@
 
 from .clients import cw_client, ddb_client, elb_client, kinesis_client, s3_client, sm_client, sqs_client
 from .integ_utils import (
+    analyze_failure_model_results,
     build_image_processing_request,
     count_features,
     count_region_request_items,
     queue_image_processing_job,
+    run_failure_model_on_image,
     run_model_on_image,
     validate_expected_feature_count,
     validate_expected_region_request_items,

--- a/src/aws/osml/utils/osml_config.py
+++ b/src/aws/osml/utils/osml_config.py
@@ -26,6 +26,7 @@ class OSMLConfig:
     SM_FLOOD_MODEL: str = os.getenv("SM_FLOOD_MODEL", "flood")
     SM_AIRCRAFT_MODEL: str = os.getenv("SM_AIRCRAFT_MODEL", "aircraft")
     SM_MULTI_CONTAINER_ENDPOINT: str = os.getenv("SM_MULTI_CONTAINER_ENDPOINT", "multi-container")
+    SM_FAILURE_MODEL: str = os.getenv("SM_FAILURE_MODEL", "failure")
 
     # HTTP model config
     HTTP_CENTERPOINT_MODEL_URL: str = os.getenv("HTTP_CENTER_POINT_MODEL_URL", None)


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Implements integration tests for the failure model that validates error handling and resilience capabilities when processing tiles with various failure scenarios. This change requires the checkerboard image already uploaded to the s3 bucket. 
> This change is dependent upon PRs for `osml-cdk-constructs` to deploy the failure model, and `guidance-for-processing-overhead-imagery-on-aws` for the updated integration test file, and checkerboard image.


### Changes
- New failure model integration tests with error validation
  - PARTIAL job completion testing (mixed success/failure tiles)
  - CloudWatch log analysis for error pattern detection
  - DynamoDB RegionProcessingJobStatus request validation for tile-level results
  - Support for checkerboard test images with color-coded failure triggers

### Files Added/Modified
- `src/aws/osml/integ/sm_failure/test_sm_failure_model.py` - Main failure model integration test
- `src/aws/osml/utils/integ_utils.py` - Added failure test functions and CloudWatch log analysis
- `src/aws/osml/utils/osml_config.py` - Added SM_FAILURE_MODEL configuration
- Updated README with failure model testing details

### Impact
- Validates proper handling of partial job completion scenarios
- Provides testing framework for error resilience

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
